### PR TITLE
UI fixes for timestamps

### DIFF
--- a/pypicloud/static/js/pypicloud.js
+++ b/pypicloud/static/js/pypicloud.js
@@ -41,14 +41,6 @@ var pypicloud = angular.module('pypicloud', ['ui.bootstrap', 'ngRoute', 'angular
         return input.slice(start);
     }
   })
-  .filter('formatDate', function() {
-    return function(ts) {
-      date = new Date(1000 * ts);
-      return date.getFullYear() + '-' +
-        ('00' + (date.getMonth() + 1)).slice(-2) + '-' +
-        ('00' + (date.getDay() + 1)).slice(-2);
-    }
-  })
   .config(['$compileProvider', function($compileProvider) {
     $compileProvider.directive('compileUnsafe', ['$compile', function($compile) {
     return function(scope, element, attrs) {

--- a/pypicloud/static/partial/index.html
+++ b/pypicloud/static/partial/index.html
@@ -53,7 +53,7 @@
             <td>{{ package.name }}</td>
             <td>{{ package.stable }}</td>
             <td>{{ package.unstable }}</td>
-            <td>{{ package.last_modified | formatDate }}</td>
+            <td>{{ package.last_modified * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
           </tr>
         </tbody>
       </table>

--- a/pypicloud/static/partial/package.html
+++ b/pypicloud/static/partial/package.html
@@ -50,7 +50,7 @@
               <a ng-href="{{ package.url }}">{{ package.version }}</a>
             </td>
             <td>
-              {{ package.last_modified | formatDate }}
+              {{ package.last_modified * 1000 | date:'yyyy-MM-dd HH:mm' }}
               <button ng-click="deletePackage(package)" ng-show="can_write && (showDelete || package.deleting)" class="btn btn-danger btn-xs pull-right" ng-disabled="package.deleting">
                 <i class="fa fa-refresh fa-spin" ng-show="package.deleting"></i>
                 Delete


### PR DESCRIPTION
For some reason the time stamps in the UI were off, for example a package uploaded today would display '2014-02-02'  in the 'Last upload' column.
I verified that the Unix timestamps sent by the server were correct and concluded that this was a UI issue.
Instead of `2014-02-02` we now see `2014-02-24 13:41`.
