### PR TITLE
Rebuild package path on migrate

### DIFF
--- a/pypicloud/scripts.py
+++ b/pypicloud/scripts.py
@@ -200,6 +200,8 @@ def migrate_packages(argv=None):
     for package in all_packages:
         print "Migrating %s" % package
         with old_storage.open(package) as data:
+            # we need to recalculate the path for the new storage config
+            del package['path']
             new_storage.upload(package, data)
 
 


### PR DESCRIPTION
We were migrating from an s3 bucket without a prefix to one with one and I noticed that it doesn't rebuild the path with the new config. This just deletes the path right before upload so it will rebuild it with `get_path`.
