### PR TITLE
Rollback any pending transactions prior to reloading schema

### DIFF
--- a/pypicloud/cache/sql.py
+++ b/pypicloud/cache/sql.py
@@ -191,6 +191,8 @@ class SQLCache(ICache):
         self.db.delete(package)
 
     def clear_all(self):
+        # Release any transactions before we go reloading schema
+        self.db.rollback()
         engine = self.dbmaker.kw['bind']
         drop_schema(engine)
         create_schema(engine)


### PR DESCRIPTION
Issue https://github.com/mathcamp/pypicloud/issues/26  appears to be related to aggressive locking that is not present in sqlite.  Issuing a session.rollback() prior to reloading schema seems to fix the hanging.
