### PR TITLE
bug fixed in redis cache, after uploading package from admin UI

### DIFF
--- a/pypicloud/views/api.py
+++ b/pypicloud/views/api.py
@@ -105,8 +105,12 @@ def download_package(context, request):
 def upload_package(context, request, content):
     """ Upload a package """
     try:
-        return request.db.upload(content.filename, content.file,
+        request.db.upload(content.filename, content.file,
                                  name=context.name)
+        response = request.response
+        request.db.reload_from_storage()
+        return response
+
     except ValueError as e:  # pragma: no cover
         return HTTPBadRequest(*e.args)
 


### PR DESCRIPTION
Bug: On S3 storage with redis as cache server, when uploaded package from admin UI, the packages uploaded to S3 but are not shown in /simple

Solution: After uploading initiate the reload from storage.
