### PR TITLE
Make PackageSummary reads consistent

### DIFF
--- a/pypicloud/cache/dynamo.py
+++ b/pypicloud/cache/dynamo.py
@@ -174,7 +174,9 @@ class DynamoCache(ICache):
         self.engine.create_schema(throughput=throughput)
 
     def save(self, package):
-        summary = self.engine.get(PackageSummary, name=package.name)
+        summary = self.engine.get(PackageSummary,
+                                  name=package.name,
+                                  consistent=True)
         if summary is None:
             summary = PackageSummary(package)
         else:


### PR DESCRIPTION
Fixes #66.

I've only tested this in py27. I have no reason to believe py26 will complain.
