### PR TITLE
Pip search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ parts
 bin
 var
 sdist
+packages
 develop-eggs
 .installed.cfg
 
@@ -41,3 +42,4 @@ pypicloud_env
 _build
 _local.db
 *.ini
+.idea

--- a/doc/topics/getting_started.rst
+++ b/doc/topics/getting_started.rst
@@ -86,3 +86,18 @@ your ``$HOME/.pypirc``::
 Now to upload a package you should run::
 
     python setup.py sdist upload -r pypicloud
+
+Searching Packages
+------------------
+After packages have been uploaded, you can search for them via pip::
+
+    pip search -i http://localhost:6543/pypi/ QUERY1 [QUERY2 ...]
+
+If you want to configure pip to use PyPI Cloud for search, you can update your
+preferences in the ``$HOME/.pip/pip.conf`` file::
+
+    [search]
+    index = http://localhost:6543/pypi/
+
+Note that this will ONLY return results from the PyPi Cloud repository. The
+official PyPi repository will not be queried.

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -51,6 +51,7 @@ def includeme(config):
     config.include('pyramid_beaker')
     config.include('pyramid_duh')
     config.include('pyramid_duh.auth')
+    config.include('pyramid_rpc.xmlrpc')
     config.include('pypicloud.auth')
     config.include('pypicloud.access')
     config.include('pypicloud.cache')
@@ -113,6 +114,8 @@ def includeme(config):
     config.add_static_view(name='static/%s' % __version__,
                            path='pypicloud:static',
                            cache_max_age=cache_max_age)
+
+    config.add_xmlrpc_endpoint('pypi', '/pypi/')
 
 
 def traceback_formatter(excpt, value, tback):

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -224,6 +224,10 @@ class ICache(object):
 
                 # Search package summaries
                 for query in summary_queries:
+                    # Skip if there is not a package summary
+                    if not package.summary:
+                        continue
+
                     # Look for this query anywhere in the package summary
                     if query.lower() in package.summary.lower():
                         # Found a match, adding to the packages_found

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -193,7 +193,49 @@ class ICache(object):
             Type of query to perform. By default, pip sends "or".
 
         """
-        raise NotImplementedError
+        name_queries = criteria.get('name', [])
+        summary_queries = criteria.get('summary', [])
+        packages = []
+        packages_found = set()
+
+        for key in self.distinct():
+            # Search all versions of this package key
+            for package in self.all(key):
+                # Skip this result if it has already been selected
+                if package.name in packages_found:
+                    continue
+
+                # Search package names
+                for query in name_queries:
+                    # Look for this query anywhere in the package name
+                    if query.lower() in package.name.lower():
+                        # Found a match, adding to the packages_found
+                        # set and generating a result
+                        packages_found.add(package.name)
+                        packages.append({
+                            'name': package.name,
+                            'summary': package.summary,
+                            'version': package.version,
+                        })
+
+                # Skip this result if it was selected by the name search
+                if package.name in packages_found:
+                    continue
+
+                # Search package summaries
+                for query in summary_queries:
+                    # Look for this query anywhere in the package summary
+                    if query.lower() in package.summary.lower():
+                        # Found a match, adding to the packages_found
+                        # set and generating a result
+                        packages_found.add(package.name)
+                        packages.append({
+                            'name': package.name,
+                            'summary': package.summary,
+                            'version': package.version,
+                        })
+
+        return packages
 
     def summary(self):
         """

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -8,8 +8,7 @@ from pyramid.settings import asbool
 import posixpath
 from pypicloud.models import Package
 from pypicloud.storage import get_storage_impl
-from pypicloud.util import parse_filename, normalize_name
-
+from pypicloud.util import create_matcher, parse_filename, normalize_name
 
 LOG = logging.getLogger(__name__)
 
@@ -198,6 +197,10 @@ class ICache(object):
         packages = []
         packages_found = set()
 
+        # Create matchers for the queries
+        match_name = create_matcher(name_queries, query_type)
+        match_summary = create_matcher(summary_queries, query_type)
+
         for key in self.distinct():
             # Search all versions of this package key
             for package in self.all(key):
@@ -206,38 +209,34 @@ class ICache(object):
                     continue
 
                 # Search package names
-                for query in name_queries:
-                    # Look for this query anywhere in the package name
-                    if query.lower() in package.name.lower():
-                        # Found a match, adding to the packages_found
-                        # set and generating a result
-                        packages_found.add(package.name)
-                        packages.append({
-                            'name': package.name,
-                            'summary': package.summary,
-                            'version': package.version,
-                        })
+                if match_name(package.name):
+                    # Found a match, adding to the packages_found
+                    # set and generating a result
+                    packages_found.add(package.name)
+                    packages.append({
+                        'name': package.name,
+                        'summary': package.summary,
+                        'version': package.version,
+                    })
 
                 # Skip this result if it was selected by the name search
                 if package.name in packages_found:
                     continue
 
-                # Search package summaries
-                for query in summary_queries:
-                    # Skip if there is not a package summary
-                    if not package.summary:
-                        continue
+                # Skip if there is not a package summary
+                if not package.summary:
+                    continue
 
-                    # Look for this query anywhere in the package summary
-                    if query.lower() in package.summary.lower():
-                        # Found a match, adding to the packages_found
-                        # set and generating a result
-                        packages_found.add(package.name)
-                        packages.append({
-                            'name': package.name,
-                            'summary': package.summary,
-                            'version': package.version,
-                        })
+                # Search package summaries
+                if match_summary(package.summary):
+                    # Found a match, adding to the packages_found
+                    # set and generating a result
+                    packages_found.add(package.name)
+                    packages.append({
+                        'name': package.name,
+                        'summary': package.summary,
+                        'version': package.version,
+                    })
 
         return packages
 

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -72,7 +72,7 @@ class ICache(object):
         for pkg in packages:
             self.save(pkg)
 
-    def upload(self, filename, data, name=None, version=None):
+    def upload(self, filename, data, name=None, version=None, summary=None):
         """
         Save this package to the storage mechanism and to the cache
 
@@ -88,6 +88,8 @@ class ICache(object):
         version : str, optional
             The version number of the package (if not provided, will be parsed
             from filename)
+        summary : str, optional
+            The summary of the package
 
         Returns
         -------
@@ -107,7 +109,7 @@ class ICache(object):
         old_pkg = self.fetch(filename)
         if old_pkg is not None and not self.allow_overwrite:
             raise ValueError("Package '%s' already exists!" % filename)
-        new_pkg = self.package_class(name, version, filename)
+        new_pkg = self.package_class(name, version, filename, summary=summary)
         self.storage.upload(new_pkg, data)
         self.save(new_pkg)
         return new_pkg
@@ -166,6 +168,29 @@ class ICache(object):
         -------
         names : list
             List of package names
+
+        """
+        raise NotImplementedError
+
+    def search(self, criteria, query_type):
+        """
+        Perform a search from pip
+
+        Parameters
+        ----------
+        criteria : dict
+            Dictionary containing the search criteria. Pip sends search criteria
+            for "name" and "summary" (typically, both of these lists have the
+            same search values).
+
+            Example:
+            {
+                "name": ["value1", "value2", ..., "valueN"],
+                "summary": ["value1", "value2", ..., "valueN"]
+            }
+
+        query_type : str
+            Type of query to perform. By default, pip sends "or".
 
         """
         raise NotImplementedError

--- a/pypicloud/cache/dynamo.py
+++ b/pypicloud/cache/dynamo.py
@@ -124,52 +124,6 @@ class DynamoCache(ICache):
             names.add(summary.name)
         return sorted(names)
 
-    def search(self, criteria, query_type):
-        """ Perform a search. """
-        name_queries = criteria.get('name', [])
-        summary_queries = criteria.get('summary', [])
-        packages = []
-        packages_found = set()
-
-        for key in self.distinct():
-            # Search all versions of this package key
-            for package in self.all(key):
-                # Skip this result if it has already been selected
-                if package.name in packages_found:
-                    continue
-
-                # Search package names
-                for query in name_queries:
-                    # Look for this query anywhere in the package name
-                    if query.lower() in package.name.lower():
-                        # Found a match, adding to the packages_found
-                        # set and generating a result
-                        packages_found.add(package.name)
-                        packages.append({
-                            'name': package.name,
-                            'summary': package.summary,
-                            'version': package.version,
-                        })
-
-                # Skip this result if it was selected by the name search
-                if package.name in packages_found:
-                    continue
-
-                # Search package summaries
-                for query in summary_queries:
-                    # Look for this query anywhere in the package summary
-                    if query.lower() in package.summary.lower():
-                        # Found a match, adding to the packages_found
-                        # set and generating a result
-                        packages_found.add(package.name)
-                        packages.append({
-                            'name': package.name,
-                            'summary': package.summary,
-                            'version': package.version,
-                        })
-
-        return packages
-
     def summary(self):
         summaries = sorted(self.engine.scan(PackageSummary),
                            key=lambda s: s.name)

--- a/pypicloud/cache/dynamo.py
+++ b/pypicloud/cache/dynamo.py
@@ -34,6 +34,7 @@ class DynamoPackage(Package, Model):
     name = Field()
     version = Field()
     last_modified = Field(data_type=datetime)
+    summary = Field()
     data = Field(data_type=dict)
 
 
@@ -122,6 +123,52 @@ class DynamoCache(ICache):
         for summary in self.engine.scan(PackageSummary):
             names.add(summary.name)
         return sorted(names)
+
+    def search(self, criteria, query_type):
+        """ Perform a search. """
+        name_queries = criteria.get('name', [])
+        summary_queries = criteria.get('summary', [])
+        packages = []
+        packages_found = set()
+
+        for key in self.distinct():
+            # Search all versions of this package key
+            for package in self.all(key):
+                # Skip this result if it has already been selected
+                if package.name in packages_found:
+                    continue
+
+                # Search package names
+                for query in name_queries:
+                    # Look for this query anywhere in the package name
+                    if query.lower() in package.name.lower():
+                        # Found a match, adding to the packages_found
+                        # set and generating a result
+                        packages_found.add(package.name)
+                        packages.append({
+                            'name': package.name,
+                            'summary': package.summary,
+                            'version': package.version,
+                        })
+
+                # Skip this result if it was selected by the name search
+                if package.name in packages_found:
+                    continue
+
+                # Search package summaries
+                for query in summary_queries:
+                    # Look for this query anywhere in the package summary
+                    if query.lower() in package.summary.lower():
+                        # Found a match, adding to the packages_found
+                        # set and generating a result
+                        packages_found.add(package.name)
+                        packages.append({
+                            'name': package.name,
+                            'summary': package.summary,
+                            'version': package.version,
+                        })
+
+        return packages
 
     def summary(self):
         summaries = sorted(self.engine.scan(PackageSummary),

--- a/pypicloud/cache/redis_cache.py
+++ b/pypicloud/cache/redis_cache.py
@@ -78,52 +78,6 @@ class RedisCache(ICache):
     def distinct(self):
         return list(self.db.smembers(self.redis_set))
 
-    def search(self, criteria, query_type):
-        """ Perform a search. """
-        name_queries = criteria.get('name', [])
-        summary_queries = criteria.get('summary', [])
-        packages = []
-        packages_found = set()
-
-        for key in self.distinct():
-            # Search all versions of this package key
-            for package in self.all(key):
-                # Skip this result if it has already been selected
-                if package.name in packages_found:
-                    continue
-
-                # Search package names
-                for query in name_queries:
-                    # Look for this query anywhere in the package name
-                    if query.lower() in package.name.lower():
-                        # Found a match, adding to the packages_found
-                        # set and generating a result
-                        packages_found.add(package.name)
-                        packages.append({
-                            'name': package.name,
-                            'summary': package.summary,
-                            'version': package.version,
-                        })
-
-                # Skip this result if it was selected by the name search
-                if package.name in packages_found:
-                    continue
-
-                # Search package summaries
-                for query in summary_queries:
-                    # Look for this query anywhere in the package summary
-                    if query.lower() in package.summary.lower():
-                        # Found a match, adding to the packages_found
-                        # set and generating a result
-                        packages_found.add(package.name)
-                        packages.append({
-                            'name': package.name,
-                            'summary': package.summary,
-                            'version': package.version,
-                        })
-
-        return packages
-
     def clear(self, package):
         del self.db[self.redis_key(package.filename)]
         self.db.srem(self.redis_filename_set(package.name), package.filename)

--- a/pypicloud/cache/redis_cache.py
+++ b/pypicloud/cache/redis_cache.py
@@ -61,9 +61,10 @@ class RedisCache(ICache):
         filename = data.pop('filename')
         last_modified = datetime.fromtimestamp(
             float(data.pop('last_modified')))
+        summary = data.pop('summary')
         kwargs = dict(((k, json.loads(v)) for k, v in data.iteritems()))
         return self.package_class(name, version, filename, last_modified,
-                                  **kwargs)
+                                  summary, **kwargs)
 
     def all(self, name):
         filenames = self.db.smembers(self.redis_filename_set(name))
@@ -76,6 +77,52 @@ class RedisCache(ICache):
 
     def distinct(self):
         return list(self.db.smembers(self.redis_set))
+
+    def search(self, criteria, query_type):
+        """ Perform a search. """
+        name_queries = criteria.get('name', [])
+        summary_queries = criteria.get('summary', [])
+        packages = []
+        packages_found = set()
+
+        for key in self.distinct():
+            # Search all versions of this package key
+            for package in self.all(key):
+                # Skip this result if it has already been selected
+                if package.name in packages_found:
+                    continue
+
+                # Search package names
+                for query in name_queries:
+                    # Look for this query anywhere in the package name
+                    if query.lower() in package.name.lower():
+                        # Found a match, adding to the packages_found
+                        # set and generating a result
+                        packages_found.add(package.name)
+                        packages.append({
+                            'name': package.name,
+                            'summary': package.summary,
+                            'version': package.version,
+                        })
+
+                # Skip this result if it was selected by the name search
+                if package.name in packages_found:
+                    continue
+
+                # Search package summaries
+                for query in summary_queries:
+                    # Look for this query anywhere in the package summary
+                    if query.lower() in package.summary.lower():
+                        # Found a match, adding to the packages_found
+                        # set and generating a result
+                        packages_found.add(package.name)
+                        packages.append({
+                            'name': package.name,
+                            'summary': package.summary,
+                            'version': package.version,
+                        })
+
+        return packages
 
     def clear(self, package):
         del self.db[self.redis_key(package.filename)]
@@ -96,6 +143,7 @@ class RedisCache(ICache):
             'version': package.version,
             'filename': package.filename,
             'last_modified': package.last_modified.strftime('%s.%f'),
+            'summary': package.summary,
         }
         for key, value in package.data.iteritems():
             data[key] = json.dumps(value)

--- a/pypicloud/cache/sql.py
+++ b/pypicloud/cache/sql.py
@@ -170,19 +170,18 @@ class SQLCache(ICache):
 
         Queries are performed as follows:
 
+            For the AND query_type, queries within a column will utilize the
+            AND operator, but will not conflict with queries in another column.
 
-        For the AND query_type, queries within a column will utilize the AND
-        operator, but will not conflict with AND queries from another column.
+                (column1 LIKE '%a%' AND column1 LIKE '%b%')
+                OR
+                (column2 LIKE '%c%' AND column2 LIKE '%d%')
 
-            (column1 LIKE '%a%' AND column1 LIKE '%b%')
-            OR
-            (column2 LIKE '%c%' AND column2 LIKE '%d%')
+            For the OR query_type, all queries will utilize the OR operator:
 
-        For the OR query_type, all queries will utilize the OR operator:
-
-            (column1 LIKE '%a%' OR column1 LIKE '%b%')
-            OR
-            (column2 LIKE '%c%' OR column2 LIKE '%d%')
+                (column1 LIKE '%a%' OR column1 LIKE '%b%')
+                OR
+                (column2 LIKE '%c%' OR column2 LIKE '%d%')
 
         """
         conditions = []

--- a/pypicloud/models.py
+++ b/pypicloud/models.py
@@ -24,12 +24,15 @@ class Package(object):
         The name of the package file
     last_modified : datetime, optional
         The datetime when this package was uploaded (default now)
+    summary : str, optional
+        The summary of the package
     **kwargs : dict
         Metadata about the package
 
     """
 
-    def __init__(self, name, version, filename, last_modified=None, **kwargs):
+    def __init__(self, name, version, filename, last_modified=None,
+                 summary=None, **kwargs):
         self.name = normalize_name(name)
         self.version = version
         self._parsed_version = None
@@ -38,6 +41,7 @@ class Package(object):
             self.last_modified = last_modified
         else:
             self.last_modified = datetime.utcnow()
+        self.summary = summary
         self.data = kwargs
 
     def get_url(self, request):
@@ -83,4 +87,5 @@ class Package(object):
             'last_modified': self.last_modified,
             'version': self.version,
             'url': self.get_url(request),
+            'summary': self.summary,
         }

--- a/pypicloud/storage/files.py
+++ b/pypicloud/storage/files.py
@@ -79,8 +79,8 @@ class FileStorage(IStorage):
             os.makedirs(destdir)
         uid = os.urandom(4).encode('hex')
 
-        # Store metadata as JSON. This could be expanded in the future if
-        # additional metadata should be stored.
+        # Store metadata as JSON. This could be expanded in the future
+        # to store additional metadata about a package (i.e. author)
         tempfile = os.path.join(destdir, '.metadata.' + uid)
         metadata = {'summary': package.summary}
         with open(tempfile, 'w') as mfile:

--- a/pypicloud/storage/files.py
+++ b/pypicloud/storage/files.py
@@ -48,7 +48,7 @@ class FileStorage(IStorage):
             if self.METADATA_FILE in files:
                 with open(os.path.join(root, self.METADATA_FILE), 'r') as mfile:
                     try:
-                        metadata = json.loads(mfile.read())
+                        metadata = json.loads(mfile)
                     except ValueError:
                         # If JSON fails to decode, don't sweat it.
                         pass
@@ -84,8 +84,7 @@ class FileStorage(IStorage):
         tempfile = os.path.join(destdir, '.metadata.' + uid)
         metadata = {'summary': package.summary}
         with open(tempfile, 'w') as mfile:
-            json_data = json.dumps(metadata)
-            mfile.write(json_data)
+            json.dumps(metadata, mfile)
 
         os.rename(tempfile, dest_meta_file)
 
@@ -99,9 +98,16 @@ class FileStorage(IStorage):
 
     def delete(self, package):
         filename = self.get_path(package)
-        meta_file = self.get_path(package, metadata=True)
+
         os.unlink(filename)
-        os.unlink(meta_file)
+
+        # Try to delete metadata file
+        meta_file = self.get_path(package, metadata=True)
+        try:
+            os.unlink(meta_file)
+        except OSError:
+            pass
+
         version_dir = os.path.dirname(filename)
         try:
             os.rmdir(version_dir)

--- a/pypicloud/storage/files.py
+++ b/pypicloud/storage/files.py
@@ -48,7 +48,7 @@ class FileStorage(IStorage):
             if self.METADATA_FILE in files:
                 with open(os.path.join(root, self.METADATA_FILE), 'r') as mfile:
                     try:
-                        metadata = json.loads(mfile)
+                        metadata = json.load(mfile)
                     except ValueError:
                         # If JSON fails to decode, don't sweat it.
                         pass
@@ -84,7 +84,7 @@ class FileStorage(IStorage):
         tempfile = os.path.join(destdir, '.metadata.' + uid)
         metadata = {'summary': package.summary}
         with open(tempfile, 'w') as mfile:
-            json.dumps(metadata, mfile)
+            json.dump(metadata, mfile)
 
         os.rename(tempfile, dest_meta_file)
 

--- a/pypicloud/storage/files.py
+++ b/pypicloud/storage/files.py
@@ -1,4 +1,5 @@
 """ Store packages as files on disk """
+import json
 from datetime import datetime
 from contextlib import closing
 
@@ -13,6 +14,8 @@ class FileStorage(IStorage):
 
     """ Stores package files on the filesystem """
 
+    METADATA_FILE = 'metadata.json'
+
     def __init__(self, request=None, **kwargs):
         self.directory = kwargs.pop('directory')
         super(FileStorage, self).__init__(request, **kwargs)
@@ -26,20 +29,42 @@ class FileStorage(IStorage):
         kwargs['directory'] = directory
         return kwargs
 
-    def get_path(self, package):
-        """ Get the fully-qualified file path for a package """
+    def get_path(self, package, metadata=False):
+        """
+        Get the fully-qualified file path for a package and its metadata file.
+        """
+        if metadata:
+            filename = self.METADATA_FILE
+        else:
+            filename = package.filename
         return os.path.join(self.directory, package.name, package.version,
-                            package.filename)
+                            filename)
 
     def list(self, factory=Package):
         for root, _, files in os.walk(self.directory):
+            metadata = {}
+
+            # Read the metadata file
+            if self.METADATA_FILE in files:
+                with open(os.path.join(root, self.METADATA_FILE), 'r') as mfile:
+                    try:
+                        metadata = json.loads(mfile.read())
+                    except ValueError:
+                        # If JSON fails to decode, don't sweat it.
+                        pass
+
             for filename in files:
+                if filename == self.METADATA_FILE:
+                    # We don't want to yield for this file
+                    continue
+
                 shortpath = root[len(self.directory):].strip('/')
                 name, version = shortpath.split('/')
                 fullpath = os.path.join(root, filename)
                 last_modified = datetime.fromtimestamp(os.path.getmtime(
                     fullpath))
-                yield factory(name, version, filename, last_modified)
+                yield factory(name, version, filename, last_modified,
+                              **metadata)
 
     def download_response(self, package):
         return FileResponse(self.get_path(package),
@@ -48,12 +73,24 @@ class FileStorage(IStorage):
 
     def upload(self, package, data):
         destfile = self.get_path(package)
+        dest_meta_file = self.get_path(package, metadata=True)
         destdir = os.path.dirname(destfile)
         if not os.path.exists(destdir):
             os.makedirs(destdir)
         uid = os.urandom(4).encode('hex')
-        tempfile = os.path.join(destdir, '.' + package.filename + '.' + uid)
+
+        # Store metadata as JSON. This could be expanded in the future if
+        # additional metadata should be stored.
+        tempfile = os.path.join(destdir, '.metadata.' + uid)
+        metadata = {'summary': package.summary}
+        with open(tempfile, 'w') as mfile:
+            json_data = json.dumps(metadata)
+            mfile.write(json_data)
+
+        os.rename(tempfile, dest_meta_file)
+
         # Write to a temporary file
+        tempfile = os.path.join(destdir, '.' + package.filename + '.' + uid)
         with open(tempfile, 'w') as ofile:
             for chunk in iter(lambda: data.read(16 * 1024), ''):
                 ofile.write(chunk)
@@ -62,7 +99,9 @@ class FileStorage(IStorage):
 
     def delete(self, package):
         filename = self.get_path(package)
+        meta_file = self.get_path(package, metadata=True)
         os.unlink(filename)
+        os.unlink(meta_file)
         version_dir = os.path.dirname(filename)
         try:
             os.rmdir(version_dir)

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -141,6 +141,7 @@ class S3Storage(IStorage):
             filename = posixpath.basename(key.key)
             name = key.get_metadata('name')
             version = key.get_metadata('version')
+            summary = key.get_metadata('summary')
 
             # We used to not store metadata. This is for backwards
             # compatibility
@@ -153,7 +154,8 @@ class S3Storage(IStorage):
 
             last_modified = boto.utils.parse_ts(key.last_modified)
 
-            pkg = factory(name, version, filename, last_modified, path=key.key)
+            pkg = factory(name, version, filename, last_modified, summary,
+                          path=key.key)
 
             yield pkg
 
@@ -176,6 +178,7 @@ class S3Storage(IStorage):
         key.key = self.get_path(package)
         key.set_metadata('name', package.name)
         key.set_metadata('version', package.version)
+        key.set_metadata('summary', package.summary)
         # S3 doesn't support uploading from a non-file stream, so we have to
         # read it into memory :(
         key.set_contents_from_string(data.read(), encrypt_key=self.use_sse)

--- a/pypicloud/util.py
+++ b/pypicloud/util.py
@@ -118,3 +118,27 @@ def getdefaults(settings, *args):
                          "(replaced by '%s')", key, canonical)
             return settings[key]
     return default
+
+
+def create_matcher(queries, query_type):
+    """
+    Create a matcher for a list of queries
+
+    Parameters
+    ----------
+    queries : list
+        List of queries
+
+    query_type: str
+        Type of query to run: ["or"|"and"]
+
+    Returns
+    -------
+        Matcher function
+
+    """
+    queries = [query.lower() for query in queries]
+    if query_type == 'or':
+        return lambda x: any((q in x.lower() for q in queries))
+    else:
+        return lambda x: all((q in x.lower() for q in queries))

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -1,5 +1,4 @@
 """ Views for simple pip interaction """
-import inspect
 import posixpath
 
 import logging

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -3,7 +3,7 @@ pep8
 nose
 mock==1.0.1
 coverage
-webtest
+webtest==2.0.24
 redis
 requests
 moto

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ pep8
 autopep8
 nose
 mock
-webtest
+webtest==2.0.24
 sphinx
 sphinx_rtd_theme
 numpydoc

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIREMENTS = [
     'pyramid_beaker',
     'pyramid_duh>=0.1.1',
     'pyramid_jinja2',
+    'pyramid_rpc',
     'pyramid_tm',
     'rsa',
     'six',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = [
     'paste',
     'passlib',
     'pycrypto',
-    'pyramid',
+    'pyramid~=1.7.5',
     'pyramid_beaker',
     'pyramid_duh>=0.1.1',
     'pyramid_jinja2',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ TEST_REQUIREMENTS = [
     'nose',
     'redis',
     'requests',
-    'webtest',
+    'webtest==2.0.24',
 ]
 
 if sys.version_info[:2] < (2, 7):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,5 @@
 """ Tests for pypicloud """
 from datetime import datetime
-from types import MethodType
 
 from collections import defaultdict
 from mock import MagicMock
@@ -19,10 +18,11 @@ except ImportError:
 
 
 def make_package(name='mypkg', version='1.1', filename=None,
-                 last_modified=datetime.utcnow(), factory=Package, **kwargs):
+                 last_modified=datetime.utcnow(), summary='summary',
+                 factory=Package, **kwargs):
     """ Convenience method for constructing a package """
     filename = filename or '%s-%s.tar.gz' % (name, version)
-    return factory(name, version, filename, last_modified, **kwargs)
+    return factory(name, version, filename, last_modified, summary, **kwargs)
 
 
 class DummyStorage(IStorage):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -140,8 +140,6 @@ class TestBaseCache(unittest.TestCase):
             cache.clear_all()
         with self.assertRaises(NotImplementedError):
             cache.save(make_package())
-        with self.assertRaises(NotImplementedError):
-            cache.search({'name': [], 'summary': []}, 'or')
 
 
 class TestSQLiteCache(unittest.TestCase):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -315,6 +315,11 @@ class TestSQLiteCache(unittest.TestCase):
             }
         ]
         packages = self.db.search(criteria, 'or')
+
+        # Sort the results so the lists are in the same order
+        expected.sort(key=lambda item: (item['name'], item['version']))
+        packages.sort(key=lambda item: (item['name'], item['version']))
+
         self.assertListEqual(packages, expected)
 
     def test_summary(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -290,7 +290,7 @@ class TestSQLiteCache(unittest.TestCase):
         pkgs = [
             make_package(factory=SQLPackage),
             make_package('somepackage', version='1.3', filename='mypath3',
-                         summary='this is MyPKG', factory=SQLPackage),
+                         summary='this is mypkg', factory=SQLPackage),
             make_package('mypkg2', '1.3.4', 'my/other/path',
                          factory=SQLPackage),
             make_package('package', factory=SQLPackage),
@@ -306,7 +306,7 @@ class TestSQLiteCache(unittest.TestCase):
             {
                 'name': 'somepackage',
                 'version': '1.3',
-                'summary': 'this is MyPKG'
+                'summary': 'this is mypkg'
             },
             {
                 'name': 'mypkg2',
@@ -315,10 +315,6 @@ class TestSQLiteCache(unittest.TestCase):
             }
         ]
         packages = self.db.search(criteria, 'or')
-
-        # Sort the results so the lists are in the same order
-        expected.sort(key=lambda item: (item['name'], item['version']))
-        packages.sort(key=lambda item: (item['name'], item['version']))
 
         self.assertListEqual(packages, expected)
 
@@ -553,7 +549,7 @@ class TestRedisCache(unittest.TestCase):
         pkgs = [
             make_package(factory=SQLPackage),
             make_package('somepackage', version='1.3', filename='mypath3',
-                         summary='this is MyPKG', factory=SQLPackage),
+                         summary='this is mypkg', factory=SQLPackage),
             make_package('mypkg2', '1.3.4', 'my/other/path',
                          factory=SQLPackage),
             make_package('package', factory=SQLPackage),
@@ -565,7 +561,7 @@ class TestRedisCache(unittest.TestCase):
             {
                 'name': 'somepackage',
                 'version': '1.3',
-                'summary': 'this is MyPKG'
+                'summary': 'this is mypkg'
             },
             {
                 'name': 'mypkg2',
@@ -735,7 +731,7 @@ class TestDynamoCache(unittest.TestCase):
         pkgs = [
             make_package(factory=DynamoPackage),
             make_package('somepackage', version='1.3', filename='mypath3',
-                         summary='this is MyPKG', factory=DynamoPackage),
+                         summary='this is mypkg', factory=DynamoPackage),
             make_package('mypkg2', '1.3.4', 'my/other/path',
                          factory=DynamoPackage),
             make_package('package', factory=DynamoPackage),
@@ -756,7 +752,7 @@ class TestDynamoCache(unittest.TestCase):
             {
                 'name': 'somepackage',
                 'version': '1.3',
-                'summary': 'this is MyPKG'
+                'summary': 'this is mypkg'
             },
         ]
         packages = self.db.search(criteria, 'or')

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -739,9 +739,9 @@ class TestDynamoCache(unittest.TestCase):
         criteria = {'name': ['mypkg'], 'summary': ['mypkg']}
         expected = [
             {
-                'name': 'somepackage',
-                'version': '1.3',
-                'summary': 'this is MyPKG'
+                'name': 'mypkg',
+                'version': '1.1',
+                'summary': 'summary'
             },
             {
                 'name': 'mypkg2',
@@ -749,10 +749,10 @@ class TestDynamoCache(unittest.TestCase):
                 'summary': 'summary'
             },
             {
-                'name': 'mypkg',
-                'version': '1.1',
-                'summary': 'summary'
-            }
+                'name': 'somepackage',
+                'version': '1.3',
+                'summary': 'this is MyPKG'
+            },
         ]
         packages = self.db.search(criteria, 'or')
         self.assertListEqual(packages, expected)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -315,7 +315,8 @@ class TestSQLiteCache(unittest.TestCase):
             }
         ]
         packages = self.db.search(criteria, 'or')
-
+        packages.sort(key=lambda item: (item['name'], item['version']))
+        expected.sort(key=lambda item: (item['name'], item['version']))
         self.assertListEqual(packages, expected)
 
     def test_summary(self):
@@ -575,6 +576,8 @@ class TestRedisCache(unittest.TestCase):
             }
         ]
         packages = self.db.search(criteria, 'or')
+        packages.sort(key=lambda item: (item['name'], item['version']))
+        expected.sort(key=lambda item: (item['name'], item['version']))
         self.assertListEqual(packages, expected)
 
     def test_multiple_packages_same_version(self):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -5,7 +5,7 @@ from mock import MagicMock, patch
 
 from . import MockServerTest, make_package
 from pypicloud.auth import _request_login
-from pypicloud.views.simple import (upload, simple, package_versions,
+from pypicloud.views.simple import (upload, search, simple, package_versions,
                                     get_fallback_packages)
 
 
@@ -64,6 +64,32 @@ class TestSimple(MockServerTest):
         self.db.upload(content.filename, content, name)
         response = upload(self.request, content, name, version)
         self.assertEqual(response.status_code, 400)
+
+    def test_search(self):
+        """ Pip search executes successfully """
+        self.params = {
+            ':action': 'file_upload',
+        }
+        name1, version1, content1 = 'foo', '1.1', MagicMock()
+        content1.filename = 'bar-1.2.tar.gz'
+        name2, version2, content2 = 'bar', '1.0', MagicMock()
+        content2.filename = 'bar-1.2.tar.gz'
+        upload(self.request, content1, name1, version1)
+        upload(self.request, content2, name2, version2)
+
+        criteria = {
+            'name': ['foo'],
+            'summary': ['foo']
+        }
+        response = search(self.request, criteria, 'or')
+        expected = [
+            {
+                'name': 'foo',
+                'version': '1.1',
+                'summary': None
+            }
+        ]
+        self.assertListEqual(response, expected)
 
     def test_list(self):
         """ Simple list should return api call """

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,5 @@
 """ Tests for package storage backends """
+import json
 import time
 from cStringIO import StringIO
 from datetime import datetime
@@ -52,15 +53,17 @@ class TestS3Storage(unittest.TestCase):
     def test_list(self):
         """ Can construct a package from a S3 Key """
         key = Key(self.bucket)
-        name, version, filename = 'mypkg', '1.2', 'pkg.tar.gz'
+        name, version, filename, summary = 'mypkg', '1.2', 'pkg.tar.gz', 'text'
         key.key = name + '/' + filename
         key.set_metadata('name', name)
         key.set_metadata('version', version)
+        key.set_metadata('summary', summary)
         key.set_contents_from_string('foobar')
         package = list(self.storage.list(Package))[0]
         self.assertEquals(package.name, name)
         self.assertEquals(package.version, version)
         self.assertEquals(package.filename, filename)
+        self.assertEquals(package.summary, summary)
 
     def test_list_no_metadata(self):
         """ Test that list works on old keys with no metadata """
@@ -73,6 +76,7 @@ class TestS3Storage(unittest.TestCase):
         self.assertEquals(package.name, name)
         self.assertEquals(package.version, version)
         self.assertEquals(package.filename, filename)
+        self.assertEquals(package.summary, None)
 
     def test_get_url(self):
         """ Mock s3 and test package url generation """
@@ -108,6 +112,7 @@ class TestS3Storage(unittest.TestCase):
         self.assertEqual(key.get_contents_as_string(), datastr)
         self.assertEqual(key.get_metadata('name'), package.name)
         self.assertEqual(key.get_metadata('version'), package.version)
+        self.assertEqual(key.get_metadata('summary'), package.summary)
 
     def test_upload_prepend_hash(self):
         """ If prepend_hash = True, attach a hash to the file path """
@@ -225,29 +230,43 @@ class TestFileStorage(unittest.TestCase):
         self.assertTrue(os.path.exists(filename))
         with open(filename, 'r') as ifile:
             self.assertEqual(ifile.read(), 'foobar')
+        meta_file = self.storage.get_path(package, metadata=True)
+        self.assertTrue(os.path.exists(meta_file))
+        with open(meta_file, 'r') as mfile:
+            self.assertEqual(json.loads(mfile.read()),
+                             {'summary': package.summary})
 
     def test_list(self):
         """ Can iterate over uploaded packages """
         package = make_package()
         path = self.storage.get_path(package)
+        meta_file = self.storage.get_path(package, metadata=True)
         os.makedirs(os.path.dirname(path))
         with open(path, 'w') as ofile:
             ofile.write('foobar')
+
+        with open(meta_file, 'w') as mfile:
+            mfile.write(json.dumps({'summary': package.summary}))
 
         pkg = list(self.storage.list(Package))[0]
         self.assertEquals(pkg.name, package.name)
         self.assertEquals(pkg.version, package.version)
         self.assertEquals(pkg.filename, package.filename)
+        self.assertEquals(pkg.summary, package.summary)
 
     def test_delete(self):
         """ delete() should remove package from storage """
         package = make_package()
         path = self.storage.get_path(package)
+        meta_path = self.storage.get_path(package, metadata=True)
         os.makedirs(os.path.dirname(path))
         with open(path, 'w') as ofile:
             ofile.write('foobar')
+        with open(meta_path, 'w') as mfile:
+            mfile.write('foobar')
         self.storage.delete(package)
         self.assertFalse(os.path.exists(path))
+        self.assertFalse(os.path.exists(meta_path))
 
     def test_create_package_dir(self):
         """ configure() will create the package dir if it doesn't exist """


### PR DESCRIPTION
Fixes #104.

I took a quick stab at getting pip search working. I've tested this in Python 2.7 using SQLite, Redis, S3, DynamoDB, and file system with no issues.

Since pip search returns a summary of the package, as well as its name and version, I added a summary field to the cache so it could be searched. For local filesystem, I have it storing this in a metadata JSON file so the cache can be repopulated. Since S3 supports metadata attributes, I just set it as a key there instead of creating a file.

Let me know if there are any areas for improvement here.