### PR TITLE
allow for overriding the download url on index.html

### DIFF
--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -88,6 +88,13 @@ The HTTP Basic Auth realm (default 'pypi')
 Replaced by ``pypi.fallback``. Setting to ``True`` has no effect. Setting to
 ``False`` will set ``pypi.fallback = none``.
 
+``pypi.download_url``
+~~~~~~~~~~~~~~~~~~~~~
+**Argument:** string, optional
+
+The URL displayed to users in the install instructions on the
+landing page. (default `app_url`)
+
 Storage
 ^^^^^^^
 ``pypi.storage``

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -115,6 +115,8 @@ def includeme(config):
     config.add_request_method(_locator, name='locator', reify=True)
     config.add_request_method(lambda x: __version__, name='pypicloud_version',
                               reify=True)
+    config.add_request_method(lambda x: settings.get('pypi.download_url'),
+                              name='custom_download_url', reify=True)
 
     cache_max_age = int(settings.get('pyramid.cache_max_age', 3600))
     config.add_static_view(name='static/%s' % __version__,

--- a/pypicloud/static/js/pypicloud.js
+++ b/pypicloud/static/js/pypicloud.js
@@ -79,6 +79,7 @@ angular.module('pypicloud', ['ui.bootstrap', 'ngRoute', 'angularFileUpload', 'ng
   $rootScope._ = _;
   $rootScope.USER = USER;
   $rootScope.ROOT = ROOT;
+  $rootScope.DOWNLOAD_URL = DOWNLOAD_URL;
   $rootScope.API = ROOT + 'api/';
   $rootScope.ADMIN = ROOT + 'admin/';
   $rootScope.IS_ADMIN = IS_ADMIN;

--- a/pypicloud/static/partial/index.html
+++ b/pypicloud/static/partial/index.html
@@ -9,7 +9,7 @@
         </p>
         <div class="text-center">
           <code>
-            pip install -i {{ ROOT }}pypi/ PACKAGE1 [PACKAGE2 ...]
+            pip install -i {{ DOWNLOAD_URL }}pypi/ PACKAGE1 [PACKAGE2 ...]
           </code>
         </div>
       </alert>

--- a/pypicloud/templates/base.jinja2
+++ b/pypicloud/templates/base.jinja2
@@ -47,6 +47,11 @@ role="navigation">
     var USER = {{ request.userid | tojson | safe }};
     var IS_ADMIN = {{ is_admin | tojson | safe }};
     var ROOT = {{ request.app_url() | tojson | safe }};
+    {% if request.custom_download_url %}
+    var DOWNLOAD_URL = {{ request.custom_download_url | tojson | safe }};
+    {% else %}
+    var DOWNLOAD_URL = {{ request.app_url() | tojson | safe }};
+    {% endif %}
     var STATIC = {{ 'pypicloud:static/' | static_url | tojson | safe }};
     var NEED_ADMIN = {{ request.access.need_admin() | tojson | safe }};
     var ACCESS_MUTABLE = {{ request.access.mutable | tojson | safe }};


### PR DESCRIPTION
This will allow users to specify `pypi.download_url` in their config file and have it take precedence over the app url for the installation help box on index.html.

If this looks good I will add configuration docs around this new field.

Example config:
```ini
[app:main]
use = egg:pypicloud

pyramid.reload_templates = True
pyramid.debug_authorization = false
pyramid.debug_notfound = false
pyramid.debug_routematch = false
pyramid.default_locale_name = en

pypi.default_read =
    everyone
pypi.default_write =
    authenticated
pypi.download_url = http://foobar.com/
```