### PR TITLE
Repair the unit tests

### DIFF
--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -6,7 +6,7 @@ coverage
 webtest
 redis
 requests
-moto
+moto<1.0.0
 flywheel>=0.2.0
 python-ldap
 mysql-python

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ sphinx_rtd_theme
 numpydoc
 redis
 requests
-moto
+moto<1.0.0
 flywheel>=0.2.0
 tox
 bumpversion

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ pylint==1.7.1
 pep8
 autopep8
 nose
-mock
+mock==1.0.1
 webtest
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Yeah, you guessed right.  moto went to 1.0.0 with some backwards breaking changes:
https://github.com/spulec/moto/blob/master/CHANGELOG.md#latest

Also, the `requirements_dev.txt` and `requirements_build.txt` files had different version requirements for `mock`.