### PR TITLE
Add `pypi.reload_interval` parameter to force cache flushing

### DIFF
--- a/pypicloud/cache/__init__.py
+++ b/pypicloud/cache/__init__.py
@@ -21,7 +21,7 @@ def includeme(config):
     cache_impl = resolver.resolve(dotted_cache)
     kwargs = cache_impl.configure(settings)
     cache = cache_impl(**kwargs)
-    cache.reload_if_needed()
+    cache.reload_if_empty()
     config.add_request_method(partial(cache_impl, **kwargs), name='db',
                               reify=True)
     return cache_impl

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -44,7 +44,7 @@ class ICache(object):
         has been exceeded.
         """
         elapsed_time = (datetime.now() - ICache.last_reloaded).seconds
-        if self.reload_interval and elapsed_time > self.reload_interval:
+        if elapsed_time >= self.reload_interval > 0:
             LOG.info("Cache is expired (%d seconds). Rebuilding from storage backend..." % elapsed_time)
             self.reload_from_storage()
             LOG.info("Cache repopulated")
@@ -56,7 +56,7 @@ class ICache(object):
             'storage': get_storage_impl(settings),
             'allow_overwrite': asbool(settings.get('pypi.allow_overwrite',
                                                    False)),
-            'reload_interval': int(settings.get('pypi.reload_interval', None))
+            'reload_interval': int(settings.get('pypi.reload_interval', 0))
         }
 
     def get_url(self, package):

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -45,7 +45,7 @@ class ICache(object):
         """
         elapsed_time = (datetime.now() - ICache.last_reloaded).seconds
         if elapsed_time >= self.reload_interval > 0:
-            LOG.info("Cache is expired (%d seconds). Rebuilding from storage backend..." % elapsed_time)
+            LOG.info("Cache is expired (%d seconds). Rebuilding from storage backend...", elapsed_time)
             self.reload_from_storage()
             LOG.info("Cache repopulated")
 

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -19,10 +19,12 @@ class ICache(object):
 
     package_class = Package
 
-    def __init__(self, request=None, storage=None, allow_overwrite=None):
+    def __init__(self, request=None, storage=None, reload_interval=None, allow_overwrite=None):
         self.request = request
         self.storage = storage(request)
         self.allow_overwrite = allow_overwrite
+        self.reload_interval = reload_interval
+        self.last_reloaded = datetime(year=1970, month=1, day=1)
 
     def reload_if_empty(self):
         """
@@ -43,6 +45,7 @@ class ICache(object):
             'storage': get_storage_impl(settings),
             'allow_overwrite': asbool(settings.get('pypi.allow_overwrite',
                                                    False)),
+            'reload_interval': int(settings.get('pypi.reload_interval', None))
         }
 
     def get_url(self, package):
@@ -70,6 +73,7 @@ class ICache(object):
         packages = self.storage.list(self.package_class)
         for pkg in packages:
             self.save(pkg)
+        self.last_reloaded = datetime.now()
 
     def upload(self, filename, data, name=None, version=None, summary=None):
         """

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -38,6 +38,17 @@ class ICache(object):
             self.reload_from_storage()
             LOG.info("Cache repopulated")
 
+    def reload_if_needed(self):
+        """
+        Reload packages from storage backend if reload_interval was set and
+        has been exceeded.
+        """
+        if self.reload_interval and\
+                (datetime.now() - self.last_reloaded).seconds > self.reload_interval:
+            LOG.info("Cache is expired. Rebuilding from storage backend...")
+            self.reload_from_storage()
+            LOG.info("Cache repopulated")
+
     @classmethod
     def configure(cls, settings):
         """ Configure the cache method with app settings """
@@ -196,6 +207,7 @@ class ICache(object):
             Type of query to perform. By default, pip sends "or".
 
         """
+        self.reload_if_needed()
         name_queries = criteria.get('name', [])
         summary_queries = criteria.get('summary', [])
         packages = []
@@ -232,6 +244,7 @@ class ICache(object):
             'unstable', and 'last_modified'.
 
         """
+        self.reload_if_needed()
         packages = []
         for name in self.distinct():
             pkg = {

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -24,7 +24,7 @@ class ICache(object):
         self.storage = storage(request)
         self.allow_overwrite = allow_overwrite
 
-    def reload_if_needed(self):
+    def reload_if_empty(self):
         """
         Reload packages from storage backend if cache is empty
 

--- a/pypicloud/cache/dynamo.py
+++ b/pypicloud/cache/dynamo.py
@@ -112,19 +112,23 @@ class DynamoCache(ICache):
         return kwargs
 
     def fetch(self, filename):
+        self.reload_if_needed()
         return self.engine.get(DynamoPackage, filename=filename)
 
     def all(self, name):
+        self.reload_if_needed()
         return sorted(self.engine.query(DynamoPackage).filter(name=name),
                       reverse=True)
 
     def distinct(self):
+        self.reload_if_needed()
         names = set()
         for summary in self.engine.scan(PackageSummary):
             names.add(summary.name)
         return sorted(names)
 
     def summary(self):
+        self.reload_if_needed()
         summaries = sorted(self.engine.scan(PackageSummary),
                            key=lambda s: s.name)
         return [s.__json__() for s in summaries]

--- a/pypicloud/cache/redis_cache.py
+++ b/pypicloud/cache/redis_cache.py
@@ -47,8 +47,10 @@ class RedisCache(ICache):
         for pkg in packages:
             self.save(pkg, pipe=pipe)
         pipe.execute()
+        self.last_reloaded = datetime.now()
 
     def fetch(self, filename):
+        self.reload_if_needed()
         data = self.db.hgetall(self.redis_key(filename))
         if not data:
             return None
@@ -67,6 +69,7 @@ class RedisCache(ICache):
                                   summary, **kwargs)
 
     def all(self, name):
+        self.reload_if_needed()
         filenames = self.db.smembers(self.redis_filename_set(name))
         pipe = self.db.pipeline()
         for filename in filenames:
@@ -76,6 +79,7 @@ class RedisCache(ICache):
         return packages
 
     def distinct(self):
+        self.reload_if_needed()
         return list(self.db.smembers(self.redis_set))
 
     def clear(self, package):

--- a/pypicloud/cache/sql.py
+++ b/pypicloud/cache/sql.py
@@ -135,8 +135,8 @@ class SQLCache(ICache):
                 self.db.close()
             request.add_finished_callback(cleanup)
 
-    def reload_if_needed(self):
-        super(SQLCache, self).reload_if_needed()
+    def reload_if_empty(self):
+        super(SQLCache, self).reload_if_empty()
         if self.request is None:
             transaction.commit()
             self.db.close()

--- a/pypicloud/cache/sql.py
+++ b/pypicloud/cache/sql.py
@@ -141,6 +141,12 @@ class SQLCache(ICache):
             transaction.commit()
             self.db.close()
 
+    def reload_if_needed(self):
+        super(SQLCache, self).reload_if_needed()
+        if self.request is None:
+            transaction.commit()
+            self.db.close()
+
     @classmethod
     def configure(cls, settings):
         kwargs = super(SQLCache, cls).configure(settings)
@@ -152,14 +158,17 @@ class SQLCache(ICache):
         return kwargs
 
     def fetch(self, filename):
+        self.reload_if_needed()
         return self.db.query(SQLPackage).filter_by(filename=filename).first()
 
     def all(self, name):
+        self.reload_if_needed()
         pkgs = self.db.query(SQLPackage).filter_by(name=name).all()
         pkgs.sort(reverse=True)
         return pkgs
 
     def distinct(self):
+        self.reload_if_needed()
         names = self.db.query(distinct(SQLPackage.name))\
             .order_by(SQLPackage.name).all()
         return [n[0] for n in names]
@@ -184,6 +193,7 @@ class SQLCache(ICache):
                 (column2 LIKE '%c%' OR column2 LIKE '%d%')
 
         """
+        self.reload_if_needed()
         conditions = []
         for key, queries in criteria.items():
             # Make sure search key exists in the package class.
@@ -221,6 +231,7 @@ class SQLCache(ICache):
         return latest_map.values()
 
     def summary(self):
+        self.reload_if_needed()
         packages = {}
         for package in self.db.query(SQLPackage):
             pkg = packages.get(package.name)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -109,7 +109,7 @@ class TestBaseCache(unittest.TestCase):
         """ Reload the cache if it's empty """
         cache = DummyCache()
         cache.reload_from_storage = MagicMock()
-        cache.reload_if_needed()
+        cache.reload_if_empty()
         self.assertTrue(cache.reload_from_storage.called)
 
     def test_no_reload_if_needed(self):
@@ -118,7 +118,7 @@ class TestBaseCache(unittest.TestCase):
         cache.reload_from_storage = MagicMock()
         cache.distinct = MagicMock()
         cache.distinct.return_value = ['hi']
-        cache.reload_if_needed()
+        cache.reload_if_empty()
         self.assertFalse(cache.reload_from_storage.called)
 
     def test_abstract_methods(self):
@@ -354,7 +354,7 @@ class TestSQLiteCache(unittest.TestCase):
         self.db.storage.list.return_value = [
             make_package(factory=SQLPackage)
         ]
-        self.db.reload_if_needed()
+        self.db.reload_if_empty()
         count = self.sql.query(SQLPackage).count()
         self.assertEqual(count, 1)
 


### PR DESCRIPTION
Hi Steve!

We're using a somewhat unusual deployment pattern for our pypicloud repositories: we have multiple copies of the frontend running, but they are all backed by the same S3 bucket (for a variety of reasons, mainly having to do with having fine-grained firewall rules for clients). This works fine except for one thing: when a new version of an already-existing package is pushed to one frontend, the other frontends never see it because the configured `ICache` assumes any changes to the underlying storage system must pass through it, unless someone logs in and rebuilds the package list.

The solution we've settled on is to add an optional `pypi.reload_interval` parameter (in seconds). When not set, behavior should be 100% identical to 0.5.5. When it is set, the cache is flushed and `reload_from_storage()` is called on any `fetch()`, `all()`, `distinct()`, `summary()`, and `search()` operations that have been called for the first time after `reload_interval` seconds have elapsed.

This is a nice tradeoff, where a single build will generally only have to pay the reload cost once, but uploading a new package version will eventually propagate on its own.

I've tested this version internally and it appears to work well for our purposes.