### PR TITLE
Allow periods in bucket name on pypicloud-make-config

### DIFF
--- a/pypicloud/scripts.py
+++ b/pypicloud/scripts.py
@@ -76,6 +76,20 @@ def promptyn(msg, default=None):
             return default
 
 
+def bucket_validate(name):
+    """ Check for valid bucket name """
+    if name.startswith('.'):
+        print "Bucket names cannot start with '.'"
+        return False
+    if name.endswith('.'):
+        print "Bucket names cannot end with '.'"
+        return False
+    if '..' in name:
+        print "Bucket names cannot contain '..'"
+        return False
+    return True
+
+
 def make_config(argv=None):
     """ Create a server config file """
     if argv is None:
@@ -134,13 +148,6 @@ def make_config(argv=None):
             data['secret_key'] = os.environ['AWS_SECRET_ACCESS_KEY']
         else:
             data['secret_key'] = prompt("AWS secret access key?")
-
-        def bucket_validate(name):
-            """ Check for valid bucket name """
-            if '.' in name:
-                print "Bucket names cannot contain '.'"
-                return False
-            return True
 
         data['s3_bucket'] = prompt("S3 bucket name?", validate=bucket_validate)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -107,3 +107,16 @@ class TestScripts(unittest.TestCase):
         self.assertTrue(ret)
         ret = scripts.promptyn('', False)
         self.assertFalse(ret)
+
+    def test_bucket_validate(self):
+        """ Validate bucket name """
+        ret = scripts.bucket_validate('bucketname')
+        self.assertTrue(ret)
+        ret = scripts.bucket_validate('bucket.name')
+        self.assertTrue(ret)
+        ret = scripts.bucket_validate('bucketname.')
+        self.assertFalse(ret)
+        ret = scripts.bucket_validate('.bucketname')
+        self.assertFalse(ret)
+        ret = scripts.bucket_validate('bucket..name')
+        self.assertFalse(ret)


### PR DESCRIPTION
I've tried to use pypicloud with s3 bucket which contains '.'s in its name.
Since pypicloud-make-config doesn't accept s3 bucket name include period,
I have to give dummy bucket name to pypicloud-make-config, and modify output
file by hand. Then pypicloud works well with the configuration file.

This change modifies validate function to accept s3 bucket name contains '.' unless

* start with period
* end with period
* have multiple periods between labels

The condition is described in the s3 official document:
http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html

Thanks,