### PR TITLE
make pypicloud-make-config python3 compatible

### DIFF
--- a/pypicloud/scripts.py
+++ b/pypicloud/scripts.py
@@ -36,8 +36,8 @@ NO_DEFAULT = object()
 
 
 def wrapped_input(msg):
-    """ Wraps raw_input for tests """
-    return raw_input(msg)
+    """ Wraps input for tests """
+    return six.moves.input(msg)
 
 
 def prompt(msg, default=NO_DEFAULT, validate=None):
@@ -150,8 +150,8 @@ def make_config(argv=None):
 
         data['s3_bucket'] = prompt("S3 bucket name?", validate=bucket_validate)
 
-    data['encrypt_key'] = b64encode(os.urandom(32))
-    data['validate_key'] = b64encode(os.urandom(32))
+    data['encrypt_key'] = b64encode(os.urandom(32)).decode('utf-8')
+    data['validate_key'] = b64encode(os.urandom(32)).decode('utf-8')
 
     data['admin'] = prompt("Admin username?")
     data['password'] = _gen_password()
@@ -166,7 +166,7 @@ def make_config(argv=None):
             data['venv'] = sys.prefix
         data['wsgi'] = 'uwsgi'
 
-    tmpl_str = resource_string('pypicloud', 'templates/config.ini.jinja2')
+    tmpl_str = resource_string('pypicloud', 'templates/config.ini.jinja2').decode('utf-8')
     template = Template(tmpl_str)
 
     config_file = template.render(**data)


### PR DESCRIPTION
pypicloud-make-config in 1.0 branch didn't work with python3.
This change make it python3 compatible.

* raw_input is renamed, use six.moves.input to support py2 and py3
* decode encrypt_key and validate_key to avoid b'...' output
* decode config.ini.jinja2 to avoid TypeError at Template()

I've tested that python2.7 and python3.6 produce equivalent config.

Regards,