### PR TITLE
S3: Set ACL for uploaded objects

### DIFF
--- a/doc/topics/storage.rst
+++ b/doc/topics/storage.rst
@@ -113,6 +113,15 @@ Enables AES-256 transparent server side encryption. See the `AWS documention
 <http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html>`_.
 Default is False.
 
+``storage.object_acl``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Argument:** string, optional
+
+Sets uploaded object's "canned" ACL. See the `AWS documentation
+<http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>`_.
+Default is "private", i.e. only the account owner will get full access.
+May be useful, if the bucket and pypicloud are hosted in different AWS accounts.
+
 CloudFront
 ----------
 This option will store your packages in S3 but use CloudFront to deliver the packages.

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -37,7 +37,7 @@ class S3Storage(IStorage):
 
     def __init__(self, request=None, bucket=None, expire_after=None,
                  bucket_prefix=None, prepend_hash=None, redirect_urls=None,
-                 use_sse=False,
+                 use_sse=False, object_acl=None,
                  **kwargs):
         super(S3Storage, self).__init__(request, **kwargs)
         self.bucket = bucket
@@ -46,6 +46,7 @@ class S3Storage(IStorage):
         self.prepend_hash = prepend_hash
         self.redirect_urls = redirect_urls
         self.use_sse = use_sse
+        self.object_acl = object_acl
 
     @classmethod
     def configure(cls, settings):
@@ -68,6 +69,8 @@ class S3Storage(IStorage):
         kwargs['use_sse'] = asbool(getdefaults(
             settings, 'storage.server_side_encryption',
             'aws.server_side_encryption', False))
+        kwargs['object_acl'] = getdefaults(settings, 'storage.object_acl',
+                                           'aws.object_acl', None)
         calling_format = settings.get('storage.calling_format',
                                       'SubdomainCallingFormat')
         kwargs['redirect_urls'] = asbool(settings.get('storage.redirect_urls',
@@ -183,7 +186,7 @@ class S3Storage(IStorage):
             key.set_metadata('summary', package.summary)
         # S3 doesn't support uploading from a non-file stream, so we have to
         # read it into memory :(
-        key.set_contents_from_string(data.read(), encrypt_key=self.use_sse)
+        key.set_contents_from_string(data.read(), encrypt_key=self.use_sse, policy=self.object_acl)
 
     def delete(self, package):
         path = self.get_path(package)


### PR DESCRIPTION
We run 2 pypiclouds in different AWS accounts, which share one bucket.
In order to make objects accessible from both accounts, custom canned ACL has to be set when uploading objects ("public-read-write" in our case). Otherwise, AWS default ACL is "private", so when user in account A uploads object to account B's bucket, users in account B can access bucket, but not the objects in it.