### PR TITLE
S3 storage config names appear to be invalid

### DIFF
--- a/doc/topics/storage.rst
+++ b/doc/topics/storage.rst
@@ -67,7 +67,7 @@ startup. If blank, the classic US region will be used.
 
 .. _s3_credentials:
 
-``storage.aws_access_key_id``, ``storage.aws_secret_access_key``
+``storage.access_key``, ``storage.secret_key``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Argument:** string, optional
 


### PR DESCRIPTION
Tried to create a config using `storage.aws_secret_access_key` and `storage.aws_access_key_id` but the server could not authenticate with S3.  Changed it to "access_key" and "secret_key" after going through error stacktrace and seeing what the source code looks for.

This also might need to be changed for the dynamodb cache backend...