### PR TITLE
Support for ldap anonymous bind and cert verification

### DIFF
--- a/doc/topics/access_control.rst
+++ b/doc/topics/access_control.rst
@@ -303,17 +303,17 @@ port, as an example: ``ldap://10.0.0.1:389``
 
 ``auth.ldap.service_dn``
 ~~~~~~~~~~~~~~~~~~~~~~~~
-**Argument:** string
+**Argument:** string, optional
 
 The FQDN of the LDAP service account used. A service account is required to
-perform the initial bind with. It only requires read access to your LDAP.
+perform the initial bind with. It only requires read access to your LDAP. If not
+specified an anonymous bind will be used.
 
 ``auth.ldap.service_password``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Argument:** string, optional
 
-The password for the LDAP service account. Default will use an empty string for
-an anonymous bind.
+The password for the LDAP service account.
 
 ``auth.ldap.service_username``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -433,3 +433,11 @@ entries for.
 
 The default behavior is to cache users forever (clearing the cache requires a
 server restart).
+
+``auth.ldap.ignore_cert``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+**Argument:** bool, optional
+
+If true then the ldap option to not verify the certificate is used. This is not
+recommended but useful if the cert name does not match the fqdn. Default is false.
+

--- a/pypicloud/access/ldap_.py
+++ b/pypicloud/access/ldap_.py
@@ -2,7 +2,7 @@
 import logging
 from collections import namedtuple
 from functools import wraps
-from pyramid.settings import aslist
+from pyramid.settings import aslist, asbool
 
 from .base import IAccessBackend
 from pypicloud.util import TimedCache
@@ -46,7 +46,7 @@ class LDAP(object):
 
     def __init__(self, admin_field, admin_value, base_dn, cache_time,
                  service_dn, service_password, service_username, url,
-                 user_search_filter, user_dn_format):
+                 user_search_filter, user_dn_format, ignore_cert):
         self._url = url
         self._service_dn = service_dn
         self._service_password = service_password
@@ -73,15 +73,25 @@ class LDAP(object):
                 User(service_username, service_dn, True),
                 None
             )
+        self._ignore_cert = ignore_cert
 
     def connect(self):
         """ Initializes the python-ldap module and does the initial bind """
+        if self._ignore_cert:
+            ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+        LOG.debug("LDAP connecting to %s", self._url)
         self._server = ldap.initialize(self._url)
-        self._server.simple_bind_s(self._service_dn, self._service_password)
+        if self._service_dn:
+            # bind with the service_dn
+            self._server.simple_bind_s(self._service_dn, self._service_password)
+        else:
+            # force a connection without binding
+            self._server.whoami_s()
 
     @reconnect
     def _fetch_user(self, username):
         """ Fetch a user entry from the LDAP server """
+        LOG.debug("LDAP fetching user %s", username)
         search_attrs = []
         if self._admin_field is not None:
             search_attrs.append(self._admin_field)
@@ -125,6 +135,7 @@ class LDAP(object):
         """
         Attempts to bind as the user, then rebinds as service user again
         """
+        LOG.debug("LDAP verifying user %s", username)
         # Empty password may successfully complete an anonymous bind.
         # Explicitly disallow empty passwords.
         if password == "":
@@ -141,10 +152,15 @@ class LDAP(object):
         else:
             return True
         finally:
-            self._server.simple_bind_s(
-                self._service_dn,
-                self._service_password
-            )
+            if self._service_dn:
+                # bind with the service_dn
+                self._server.simple_bind_s(
+                    self._service_dn,
+                    self._service_password
+                )
+            else:
+                # force a connection without binding
+                self._server.whoami_s()
 
 
 class LDAPAccessBackend(IAccessBackend):
@@ -163,12 +179,13 @@ class LDAPAccessBackend(IAccessBackend):
             admin_value=aslist(settings.get('auth.ldap.admin_value', [])),
             base_dn=settings.get('auth.ldap.base_dn'),
             cache_time=settings.get('auth.ldap.cache_time'),
-            service_dn=settings['auth.ldap.service_dn'],
+            service_dn=settings.get('auth.ldap.service_dn'),
             service_password=settings.get('auth.ldap.service_password', ''),
             service_username=settings.get('auth.ldap.service_username'),
             url=settings['auth.ldap.url'],
             user_dn_format=settings.get('auth.ldap.user_dn_format'),
             user_search_filter=settings.get('auth.ldap.user_search_filter'),
+            ignore_cert=asbool(settings.get('auth.ldap.ignore_cert'))
         )
         conn.connect()
         kwargs['conn'] = conn
@@ -189,6 +206,8 @@ class LDAPAccessBackend(IAccessBackend):
         return []  # pragma: no cover
 
     def is_admin(self, username):
+        if not username:
+            return False
         user = self.conn.get_user(username)
         return user is not None and user.is_admin
 


### PR DESCRIPTION
Anonymous bind for the service account doesn't work if you specify a username and blank password, so add support for not specifying a service_dn at all.

Also add support for ignoring cert verification on the ldaps protocol which is a valid use case. LDAP is really picky on the hostname and the cert name matching, which breaks when you use DNS aliases.

Also add some debug logging I needed while troubleshooting.