### PR TITLE
fix array exception when setting storage.cloud_front_key_file

### DIFF
--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -293,7 +293,7 @@ class CloudFrontS3Storage(S3Storage):
         if private_key is None:
             key_file = settings.get('storage.cloud_front_key_file')
             if key_file:
-                with open(key_file, 'r') as ifile:
+                with open(key_file, 'rb') as ifile:
                     private_key = ifile.read()
         else:
             private_key = private_key.encode('utf-8')


### PR DESCRIPTION
When I set storage.cloud_front_key_file = /etc/pypicloud/key.pem in config.ini ( key.pem was copied into /etc/pypicloud), start the app. I got the exception as below 
```
Loading paste environment: config:/etc/pypicloud/config.ini
INFO 2018-07-16 05:01:14,821 [botocore.vendored.requests.packages.urllib3.connectionpool] Starting new HTTPS connection (1): inspectorio-files-upload2.s3.amazonaws.com
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/local/lib/python3.5/dist-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/usr/local/lib/python3.5/dist-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/local/lib/python3.5/dist-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/usr/local/lib/python3.5/dist-packages/paste/deploy/util.py", line 58, in fix_call
    reraise(*exc_info)
  File "/usr/local/lib/python3.5/dist-packages/paste/deploy/compat.py", line 32, in reraise
    raise e.with_traceback(tb)
  File "/usr/local/lib/python3.5/dist-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/usr/local/lib/python3.5/dist-packages/pypicloud/__init__.py", line 146, in main
    config.include('pypicloud')
  File "/usr/local/lib/python3.5/dist-packages/pyramid/config/__init__.py", line 839, in include
    c(configurator)
  File "/usr/local/lib/python3.5/dist-packages/pypicloud/__init__.py", line 76, in includeme
    config.include('pypicloud.cache')
  File "/usr/local/lib/python3.5/dist-packages/pyramid/config/__init__.py", line 839, in include
    c(configurator)
  File "/usr/local/lib/python3.5/dist-packages/pypicloud/cache/__init__.py", line 27, in includeme
    kwargs = cache_impl.configure(settings)
  File "/usr/local/lib/python3.5/dist-packages/pypicloud/cache/sql.py", line 141, in configure
    kwargs = super(SQLCache, cls).configure(settings)
  File "/usr/local/lib/python3.5/dist-packages/pypicloud/cache/base.py", line 43, in configure
    'storage': get_storage_impl(settings),
  File "/usr/local/lib/python3.5/dist-packages/pypicloud/storage/__init__.py", line 22, in get_storage_impl
    kwargs = storage_impl.configure(settings)
  File "/usr/local/lib/python3.5/dist-packages/pypicloud/storage/s3.py", line 301, in configure
    private_key, password=None, backend=default_backend())
  File "/usr/local/lib/python3.5/dist-packages/cryptography/hazmat/primitives/serialization.py", line 20, in load_pem_private_key
    return backend.load_pem_private_key(data, password)
  File "/usr/local/lib/python3.5/dist-packages/cryptography/hazmat/backends/openssl/backend.py", line 1014, in load_pem_private_key
    password,
  File "/usr/local/lib/python3.5/dist-packages/cryptography/hazmat/backends/openssl/backend.py", line 1198, in _load_key
    mem_bio = self._bytes_to_bio(data)
  File "/usr/local/lib/python3.5/dist-packages/cryptography/hazmat/backends/openssl/backend.py", line 436, in _bytes_to_bio
    data_char_p = self._ffi.new("char[]", data)
TypeError: initializer for ctype 'char[]' must be a bytes or list or tuple, not str
```
To fix this, just open the pem file as binary.
