### PR TITLE
LDAP admin fix

### DIFF
--- a/pypicloud/access/ldap_.py
+++ b/pypicloud/access/ldap_.py
@@ -138,8 +138,8 @@ class LDAP(object):
         is_admin = False
         if self._admin_field is not None:
             if self._admin_field in attributes:
-                is_admin = any((val in attributes[self._admin_field]
-                                for val in self._admin_value))
+                is_admin = any((val in self._admin_value 
+                                for val in attributes[self._admin_field]))
 
         return User(username, dn, is_admin)
 


### PR DESCRIPTION
Iterating over the list returned from AD instead of the admin value specified (which is a string).

Setting the auth.ldap.admin_field to memberOf
Setting the auth.ldap.admin_value to "a given group value"

This fix iterates over the AD values returned instead of iterating over the string admin_value.