### PR TITLE
Fixing the logic for LDAP reconnects

### DIFF
--- a/pypicloud/access/ldap_.py
+++ b/pypicloud/access/ldap_.py
@@ -33,7 +33,7 @@ def reconnect(func):
             return func(self, *args, **kwargs)
         except ldap.LDAPError:
             self.connect()
-            return func(*args, **kwargs)
+            return func(self, *args, **kwargs)
 
     return _reconnect
 


### PR DESCRIPTION
Without the self inside the try, reconnecting fails to pass the correct data to the wrapped function.