### PR TITLE
Summary sent to s3 to be normalized and stripped of non-ASCII characters

### DIFF
--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -1,5 +1,6 @@
 """ Store packages in S3 """
 import posixpath
+import unicodedata
 
 import boto3
 import logging
@@ -189,7 +190,9 @@ class S3Storage(ObjectStoreStorage):
             kwargs["StorageClass"] = self.storage_class
         metadata = {"name": package.name, "version": package.version}
         if package.summary:
-            metadata["summary"] = package.summary
+            metadata["summary"] = u''.join(
+                c for c in unicodedata.normalize('NFKD', package.summary) if ord(c) < 128
+            )
         key.put(Metadata=metadata, Body=datastream, **kwargs)
 
     def delete(self, package):


### PR DESCRIPTION
    Some unicode characters might pose problem for boto, which in case
    of validators package summary 'Python Data Validation for Humans™'
    threw a valdiation error


Stack trace:
```
Parameter validation failed:
                                        Non ascii characters found in S3 metadata for key "summary", value: "Python Data Validation for Humans™.".  
                                        S3 metadata can only contain ASCII characters. 
                                        Traceback (most recent call last):
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/handlers.py", line 567, in validate_ascii_metadata
                                            value.encode('ascii')
                                        UnicodeEncodeError: 'ascii' codec can't encode character '\u2122' in position 33: ordinal not in range(128)
                                        
                                        During handling of the above exception, another exception occurred:
                                        
                                        Traceback (most recent call last):
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid/tweens.py", line 39, in excview_tween
                                            response = handler(request)
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid/router.py", line 156, in handle_request
                                            view_name
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid/view.py", line 642, in _call_view
                                            response = view_callable(context, request)
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid/config/views.py", line 181, in __call__
                                            return view(context, request)
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid/viewderivers.py", line 390, in attr_view
                                            return view(context, request)
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid/viewderivers.py", line 368, in predicate_wrapper
                                            return view(context, request)
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid/viewderivers.py", line 439, in rendered_view
                                            result = view(context, request)
                                          File "/opt/pypi/lib/python3.5/site-packages/pyramid_duh/params.py", line 306, in param_twiddler
                                            return fxn(**scope)
                                          File "/opt/pypi/lib/python3.5/site-packages/pypicloud/views/simple.py", line 37, in upload
                                            version=version, summary=summary)
                                          File "/opt/pypi/lib/python3.5/site-packages/pypicloud/cache/base.py", line 118, in upload
                                            self.storage.upload(new_pkg, data)
                                          File "/opt/pypi/lib/python3.5/site-packages/pypicloud/storage/s3.py", line 229, in upload
                                            key.put(Metadata=metadata, Body=datastream, **kwargs)
                                          File "/opt/pypi/lib/python3.5/site-packages/boto3/resources/factory.py", line 520, in do_action
                                            response = action(self, *args, **kwargs)
                                          File "/opt/pypi/lib/python3.5/site-packages/boto3/resources/action.py", line 83, in __call__
                                            response = getattr(parent.meta.client, operation_name)(**params)
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/client.py", line 314, in _api_call
                                            return self._make_api_call(operation_name, kwargs)
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/client.py", line 586, in _make_api_call
                                            api_params, operation_model, context=request_context)
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/client.py", line 619, in _convert_to_request_dict
                                            api_params, operation_model, context)
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/client.py", line 648, in _emit_api_params
                                            params=api_params, model=operation_model, context=context)
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/hooks.py", line 227, in emit
                                            return self._emit(event_name, kwargs)
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/hooks.py", line 210, in _emit
                                            response = handler(**kwargs)
                                          File "/opt/pypi/lib/python3.5/site-packages/botocore/handlers.py", line 575, in validate_ascii_metadata
                                            report=error_msg)
                                        botocore.exceptions.ParamValidationError: Parameter validation failed:
                                        Non ascii characters found in S3 metadata for key "summary", value: "Python Data Validation for Humans™.".  
                                        S3 metadata can only contain ASCII characters.
```
Context: we're running pypicloud 1.0.5 at the moment on python 3.5, and are uploading other wheels for speedier production/tests installation. (happens only in case we haven't found a wheel)