### PR TITLE
Replace defaukt http://pypi.python.org with https://pypi.org for fall…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ PyPI Cloud
 .. |docs| image:: https://readthedocs.org/projects/pypicloud/badge/?version=latest
 .. _docs: http://pypicloud.readthedocs.org/
 .. |downloads| image:: http://pepy.tech/badge/pypicloud
-.. _downloads: http://pypi.python.org/pypi/pypicloud
+.. _downloads: https://pypi.org/pypi/pypicloud
 
 This package is a Pyramid web app that provides a PyPI server where the packages
 are stored on Amazon's Simple Storage Service (S3) or Google's Cloud Storage

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -121,7 +121,7 @@ def includeme(config):
         config.registry.fallback_url = settings["pypi.fallback_url"]
         config.registry.fallback_base_url = None
     else:
-        config.registry.fallback_base_url = "https://pypi.python.org"
+        config.registry.fallback_base_url = "https://pypi.org"
         config.registry.fallback_url = None
     config.add_request_method(_fallback_simple, name="fallback_simple", reify=True)
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -111,9 +111,9 @@ class TestSimple(MockServerTest):
         version = "1.1"
         name = "foo"
         filename = "%s-%s.tar.gz" % (name, version)
-        url = "http://pypi.python.org/pypi/%s/%s" % (name, filename)
+        url = "https://pypi.org/pypi/%s/%s" % (name, filename)
         wheelname = "%s-%s.whl" % (name, version)
-        wheel_url = "http://pypi.python.org/pypi/%s/%s" % (name, wheelname)
+        wheel_url = "https://pypi.org/pypi/%s/%s" % (name, wheelname)
         dist = MagicMock()
         dist.name = name
         self.request.locator.get_project.return_value = {
@@ -134,9 +134,9 @@ class TestSimple(MockServerTest):
         version = "1.1"
         name = "foo"
         filename = "%s-%s.tar.gz" % (name, version)
-        url = "http://pypi.python.org/pypi/%s/%s" % (name, filename)
+        url = "https://pypi.org/pypi/%s/%s" % (name, filename)
         wheelname = "%s-%s.whl" % (name, version)
-        wheel_url = "http://pypi.python.org/pypi/%s/%s" % (name, wheelname)
+        wheel_url = "https://pypi.org/pypi/%s/%s" % (name, wheelname)
         dist = MagicMock()
         dist.name = name
         self.request.locator.get_project.return_value = {
@@ -153,8 +153,8 @@ class PackageReadTestBase(unittest.TestCase):
 
     fallback = None
     always_show_upstream = None
-    fallback_url = "http://pypi.python.org/pypi/"
-    fallback_base_url = "http://pypi.python.org/"
+    fallback_url = "https://pypi.org/pypi/"
+    fallback_base_url = "https://pypi.org/"
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
…back_base_url

    python package index migrated over a year ago to new domain and new tech stack

    plus the ssl encrypted connection is becoming required