### PR TITLE
Add option to disallow fallback for certain packages

### DIFF
--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -54,6 +54,14 @@ https://pypi.python.org/simple)
 This takes precendence over ``pypi.fallback`` by causing redirects to go to:
 ``pypi.fallback_base_url/<simple|pypi>``. (default https://pypi.python.org)
 
+``pypi.disallow_fallback``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Argument:** list, optional
+
+List of packages that should not be fetch from ``pypi.fallback_base_url``.
+This is useful if private packages have the same name as a package in
+``pypi.fallback_base_url`` and you don't want it to be replaced.
+
 ``pypi.default_read``
 ~~~~~~~~~~~~~~~~~~~~~
 **Argument:** list, optional

--- a/pypicloud/access/base.py
+++ b/pypicloud/access/base.py
@@ -68,6 +68,7 @@ class IAccessBackend(object):
         request=None,
         default_read=None,
         default_write=None,
+        disallow_fallback=None,
         cache_update=None,
         pwd_context=None,
         token_expiration=ONE_WEEK,
@@ -76,6 +77,7 @@ class IAccessBackend(object):
         self.request = request
         self.default_read = default_read
         self.default_write = default_write
+        self.disallow_fallback = disallow_fallback
         self.cache_update = cache_update
         self.pwd_context = pwd_context
         self.token_expiration = token_expiration
@@ -90,6 +92,7 @@ class IAccessBackend(object):
                 settings.get("pypi.default_read", ["authenticated"])
             ),
             "default_write": aslist(settings.get("pypi.default_write", [])),
+            "disallow_fallback": aslist(settings.get("pypi.disallow_fallback", [])),
             "cache_update": aslist(
                 settings.get("pypi.cache_update", ["authenticated"])
             ),
@@ -129,6 +132,11 @@ class IAccessBackend(object):
                     all_perms[principal] += ("write",)
                 else:
                     all_perms[principal] = ("write",)
+
+        # add fallback permissions
+        for principal in all_perms:
+            if package not in self.disallow_fallback:
+                all_perms[principal] += ("fallback",)
         return all_perms
 
     def get_acl(self, package):

--- a/pypicloud/access/base.py
+++ b/pypicloud/access/base.py
@@ -68,7 +68,7 @@ class IAccessBackend(object):
         request=None,
         default_read=None,
         default_write=None,
-        disallow_fallback=None,
+        disallow_fallback=(),
         cache_update=None,
         pwd_context=None,
         token_expiration=ONE_WEEK,
@@ -134,8 +134,8 @@ class IAccessBackend(object):
                     all_perms[principal] = ("write",)
 
         # add fallback permissions
-        for principal in all_perms:
-            if package not in self.disallow_fallback:
+        if package not in self.disallow_fallback:
+            for principal in all_perms:
                 all_perms[principal] += ("fallback",)
         return all_perms
 

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -137,6 +137,8 @@ def get_fallback_packages(request, package_name, redirect=True):
     """ Get all package versions for a package from the fallback_base_url """
     dists = request.locator.get_project(package_name)
     pkgs = {}
+    if not request.access.has_permission(package_name, 'fallback'):
+        return pkgs
     for version, url_set in six.iteritems(dists.get("urls", {})):
         dist = dists[version]
         for url in url_set:

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -137,7 +137,7 @@ def get_fallback_packages(request, package_name, redirect=True):
     """ Get all package versions for a package from the fallback_base_url """
     dists = request.locator.get_project(package_name)
     pkgs = {}
-    if not request.access.has_permission(package_name, 'fallback'):
+    if not request.access.has_permission(package_name, "fallback"):
         return pkgs
     for version, url_set in six.iteritems(dists.get("urls", {})):
         dist = dists[version]

--- a/tests/test_access_backends.py
+++ b/tests/test_access_backends.py
@@ -270,14 +270,23 @@ class TestBaseBackend(BaseACLTest):
         self.backend.default_read = ["everyone", "authenticated"]
         self.backend.default_write = []
         perms = self.backend.allowed_permissions("anypkg")
-        self.assertEqual(perms, {Everyone: ("read",), Authenticated: ("read",)})
+        self.assertEqual(perms, {Everyone: ("read", "fallback"),
+                                 Authenticated: ("read", "fallback")})
 
     def test_has_permission_default_write(self):
         """ If no user/group permissions on a package, use default_write """
         self.backend.default_read = ["authenticated"]
         self.backend.default_write = ["authenticated"]
         perms = self.backend.allowed_permissions("anypkg")
-        self.assertEqual(perms, {Authenticated: ("read", "write")})
+        self.assertEqual(perms, {Everyone: ("read", "write", "fallback"),
+                                 Authenticated: ("read", "write", "fallback")})
+
+    def test_package_fallback_disallowed(self):
+        """ If package is in disallow_fallback list, it won't have fallback permissions """
+        self.backend.default_read = ["authenticated"]
+        self.backend.disallow_fallback = ["anypkg"]
+        perms = self.backend.allowed_permissions("anypkg")
+        self.assertEqual(perms, {Authenticated: ("read",)})
 
     def test_admin_principal(self):
         """ Admin user has the 'admin' principal """

--- a/tests/test_access_backends.py
+++ b/tests/test_access_backends.py
@@ -1402,9 +1402,9 @@ class TestLDAPMockBackend(BaseLDAPTest):
         self.assertEqual(user, {"username": "root", "admin": True, "groups": []})
 
     def test_allowed_permissions(self):
-        """ Default settings will only allow authenticated to read """
+        """ Default settings will only allow authenticated to read and fallback"""
         perms = self.backend.allowed_permissions("mypkg")
-        self.assertEqual(perms, {Authenticated: ("read",)})
+        self.assertEqual(perms, {Authenticated: ("read", "fallback")})
 
     def test_user_package_perms(self):
         """ No user package perms in LDAP """

--- a/tests/test_access_backends.py
+++ b/tests/test_access_backends.py
@@ -278,15 +278,7 @@ class TestBaseBackend(BaseACLTest):
         self.backend.default_read = ["authenticated"]
         self.backend.default_write = ["authenticated"]
         perms = self.backend.allowed_permissions("anypkg")
-        self.assertEqual(perms, {Everyone: ("read", "write", "fallback"),
-                                 Authenticated: ("read", "write", "fallback")})
-
-    def test_package_fallback_disallowed(self):
-        """ If package is in disallow_fallback list, it won't have fallback permissions """
-        self.backend.default_read = ["authenticated"]
-        self.backend.disallow_fallback = ["anypkg"]
-        perms = self.backend.allowed_permissions("anypkg")
-        self.assertEqual(perms, {Authenticated: ("read",)})
+        self.assertEqual(perms, {Authenticated: ("read", "write", "fallback")})
 
     def test_admin_principal(self):
         """ Admin user has the 'admin' principal """
@@ -1414,6 +1406,13 @@ class TestLDAPMockBackend(BaseLDAPTest):
         """ Default settings will only allow authenticated to read and fallback"""
         perms = self.backend.allowed_permissions("mypkg")
         self.assertEqual(perms, {Authenticated: ("read", "fallback")})
+
+    def test_package_fallback_disallowed(self):
+        """ If package is in disallow_fallback list, it won't have fallback permissions """
+        self.backend.default_read = ["authenticated"]
+        self.backend.disallow_fallback = ["anypkg"]
+        perms = self.backend.allowed_permissions("anypkg")
+        self.assertEqual(perms, {Authenticated: ("read",)})
 
     def test_user_package_perms(self):
         """ No user package perms in LDAP """

--- a/tests/test_access_backends.py
+++ b/tests/test_access_backends.py
@@ -270,8 +270,9 @@ class TestBaseBackend(BaseACLTest):
         self.backend.default_read = ["everyone", "authenticated"]
         self.backend.default_write = []
         perms = self.backend.allowed_permissions("anypkg")
-        self.assertEqual(perms, {Everyone: ("read", "fallback"),
-                                 Authenticated: ("read", "fallback")})
+        self.assertEqual(
+            perms, {Everyone: ("read", "fallback"), Authenticated: ("read", "fallback")}
+        )
 
     def test_has_permission_default_write(self):
         """ If no user/group permissions on a package, use default_write """

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -146,6 +146,25 @@ class TestSimple(MockServerTest):
         pkgs = get_fallback_packages(self.request, "foo")
         self.assertEqual(pkgs, {filename: url, wheelname: wheel_url})
 
+    def test_disallow_fallback_packages(self):
+        """ Disallow fetch fallback packages """
+        self.request.locator = MagicMock()
+        version = "1.1"
+        name = "foo"
+        filename = "%s-%s.tar.gz" % (name, version)
+        url = "http://pypi.python.org/pypi/%s/%s" % (name, filename)
+        wheelname = "%s-%s.whl" % (name, version)
+        wheel_url = "http://pypi.python.org/pypi/%s/%s" % (name, wheelname)
+        dist = MagicMock()
+        dist.name = name
+        self.request.locator.get_project.return_value = {
+            version: dist,
+            "urls": {version: [url, wheel_url]},
+        }
+        self.request.access.has_permission = MagicMock(return_value=False)
+        pkgs = get_fallback_packages(self.request, "foo")
+        self.assertEqual(pkgs, {})
+
 
 class PackageReadTestBase(unittest.TestCase):
 


### PR DESCRIPTION
This is my hacky attempt at providing the functionality requested on #214.

Let me know if you have any suggestions or if you don't think this is the right approach to tackle this problem.

This is useful if your internal packages shadow names from Pypi and you want to avoid your internal packages getting upgraded to a higher version of a different package present in Pypi.
To use this you just have to add a list of package names in config.ini. E.g. 
```
pypi.disallow_fallback =
  flask
  numpy
```