### PR TITLE
Add PEP-503 data-requires-python attribute

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,11 +2,14 @@ Changelog
 =========
 If you are upgrading an existing installation, read :ref:`the instructions <upgrade>`
 
+Next version
+------------
+* Per PEP 503, if the package is uploaded with the `requires_python` metadata, the simple package index
+  will advertise it through the data-requires-python attribute and allows pip to ignore it when matching.
+
 1.0.13 - 2020/1/1
 -----------------
 * Add option to use IAM signer on GCS (:pr:`226`)
-* Per PEP 503, if the package is uploaded with the `requires_python` metadata, the simple package index
-  will advertise it through the data-requires-python attribute and allows pip to ignore it when matching.
 
 1.0.12 - 2019/12/11
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ If you are upgrading an existing installation, read :ref:`the instructions <upgr
 1.0.13 - 2020/1/1
 -----------------
 * Add option to use IAM signer on GCS (:pr:`226`)
+* Per PEP 503, if the package is uploaded with the `requires_python` metadata, the simple package index
+  will advertise it through the data-requires-python attribute and allows pip to ignore it when matching.
 
 1.0.12 - 2019/12/11
 -------------------

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -74,7 +74,7 @@ class ICache(object):
         for pkg in packages:
             self.save(pkg)
 
-    def upload(self, filename, data, name=None, version=None, summary=None):
+    def upload(self, filename, data, name=None, version=None, summary=None, requires_python=None):
         """
         Save this package to the storage mechanism and to the cache
 
@@ -92,6 +92,8 @@ class ICache(object):
             from filename)
         summary : str, optional
             The summary of the package
+        requires_python : str, optional
+            The Python version requirement
 
         Returns
         -------
@@ -111,7 +113,7 @@ class ICache(object):
         old_pkg = self.fetch(filename)
         if old_pkg is not None and not self.allow_overwrite:
             raise ValueError("Package '%s' already exists!" % filename)
-        new_pkg = self.package_class(name, version, filename, summary=summary)
+        new_pkg = self.package_class(name, version, filename, summary=summary, requires_python=requires_python)
         self.storage.upload(new_pkg, data)
         self.save(new_pkg)
         return new_pkg

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -74,7 +74,15 @@ class ICache(object):
         for pkg in packages:
             self.save(pkg)
 
-    def upload(self, filename, data, name=None, version=None, summary=None, requires_python=None):
+    def upload(
+        self,
+        filename,
+        data,
+        name=None,
+        version=None,
+        summary=None,
+        requires_python=None,
+    ):
         """
         Save this package to the storage mechanism and to the cache
 
@@ -113,7 +121,9 @@ class ICache(object):
         old_pkg = self.fetch(filename)
         if old_pkg is not None and not self.allow_overwrite:
             raise ValueError("Package '%s' already exists!" % filename)
-        new_pkg = self.package_class(name, version, filename, summary=summary, requires_python=requires_python)
+        new_pkg = self.package_class(
+            name, version, filename, summary=summary, requires_python=requires_python
+        )
         self.storage.upload(new_pkg, data)
         self.save(new_pkg)
         return new_pkg

--- a/pypicloud/templates/package.jinja2
+++ b/pypicloud/templates/package.jinja2
@@ -4,8 +4,8 @@
   <title>Package Index</title>
 </head>
 <body>
-  {% for filename, url in pkgs|dictsort %}
-    <a href="{{ url }}">{{ filename }}</a><br>
+  {% for filename, pkg in pkgs|dictsort %}
+    <a href="{{ pkg.url }}"{% if pkg.requires_python %} data-requires-python="{{ pkg.requires_python }}"{% endif %}>{{ filename }}</a><br>
   {%- endfor %}
 </body>
 </html>

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -19,7 +19,9 @@ LOG = logging.getLogger(__name__)
 @view_config(context=Root, request_method="POST", subpath=(), renderer="json")
 @view_config(context=SimpleResource, request_method="POST", subpath=(), renderer="json")
 @argify
-def upload(request, content, name=None, version=None, summary=None, requires_python=None):
+def upload(
+    request, content, name=None, version=None, summary=None, requires_python=None
+):
     """ Handle update commands """
     action = request.param(":action", "file_upload")
     # Direct uploads from the web UI go here, and don't have a name/version
@@ -127,7 +129,7 @@ def package_versions_json(context, request):
             max_version = version
 
         response["releases"].setdefault(version_str, []).append(
-            {"filename": filename, "url": pkg['url']}
+            {"filename": filename, "url": pkg["url"]}
         )
     if max_version is not None:
         response["urls"] = response["releases"].get(str(max_version), [])
@@ -155,8 +157,8 @@ def packages_to_dict(request, packages):
     pkgs = {}
     for package in packages:
         pkgs[package.filename] = {
-            'url': package.get_url(request),
-            'requires_python': package.data.get('requires_python'),
+            "url": package.get_url(request),
+            "requires_python": package.data.get("requires_python"),
         }
     return pkgs
 

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -148,7 +148,7 @@ def get_fallback_packages(request, package_name, redirect=True):
             filename = posixpath.basename(url)
             if not redirect:
                 url = request.app_url("api", "package", dist.name, filename)
-            pkgs[filename] = url
+            pkgs[filename] = {"url": url}
     return pkgs
 
 
@@ -263,8 +263,8 @@ def _simple_cache_always_show(context, request):
                 pkgs = get_fallback_packages(request, context.name)
                 stored_pkgs = packages_to_dict(request, packages)
                 # Overwrite existing package urls
-                for filename, url in six.iteritems(stored_pkgs):
-                    pkgs[filename] = url
+                for filename, data in six.iteritems(stored_pkgs):
+                    pkgs[filename] = data
                 return _pkg_response(pkgs)
             else:
                 return request.request_login()
@@ -272,8 +272,8 @@ def _simple_cache_always_show(context, request):
             pkgs = get_fallback_packages(request, context.name, False)
             stored_pkgs = packages_to_dict(request, packages)
             # Overwrite existing package urls
-            for filename, url in six.iteritems(stored_pkgs):
-                pkgs[filename] = url
+            for filename, data in six.iteritems(stored_pkgs):
+                pkgs[filename] = data
             return _pkg_response(pkgs)
     else:
         if not request.access.can_update_cache():

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -37,7 +37,7 @@ def upload(request, content, name=None, version=None, summary=None, requires_pyt
                 name=name,
                 version=version,
                 summary=summary,
-                requires_python=requires_python,
+                requires_python=requires_python or None,
             )
         except ValueError as e:
             return HTTPConflict(*e.args)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -29,6 +29,7 @@ class TestPackages(MockServerTest):
                 p = MagicMock()
                 p.filename = package_name
                 p.get_url.return_value = package_name + ".ext"
+                p.data = {}
                 return p
 
             d = {
@@ -40,5 +41,10 @@ class TestPackages(MockServerTest):
 
         self.request.db.all.side_effect = get_packages
         result = list_packages(self.request)
-        expected = {"b0": "b0.ext", "c0": "c0.ext", "c1": "c1.ext", "c2": "c2.ext"}
+        expected = {
+            "b0": {"requires_python": None, "url": "b0.ext"},
+            "c0": {"requires_python": None, "url": "c0.ext"},
+            "c1": {"requires_python": None, "url": "c1.ext"},
+            "c2": {"requires_python": None, "url": "c2.ext"},
+        }
         self.assertEqual(result, {"pkgs": expected})

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -249,7 +249,10 @@ class PackageReadTestBase(unittest.TestCase):
         """ When requested, the endpoint should serve the packages """
         ret = package_versions(self.package, request)
         self.assertEqual(
-            ret, {"pkgs": {self.package.filename: self.package.get_url(request)}}
+            ret, {"pkgs": {self.package.filename: {
+                'url': self.package.get_url(request),
+                'requires_python': None,
+            }}},
         )
         # Check the /json endpoint too
         ret = package_versions_json(self.package, request)
@@ -278,7 +281,10 @@ class PackageReadTestBase(unittest.TestCase):
             ret,
             {
                 "pkgs": {
-                    self.package.filename: self.package.get_url(request),
+                    self.package.filename: {
+                        'url': self.package.get_url(request),
+                        'requires_python': None,
+                    },
                     f2name: self.fallback_packages[f2name],
                 }
             },

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -249,10 +249,15 @@ class PackageReadTestBase(unittest.TestCase):
         """ When requested, the endpoint should serve the packages """
         ret = package_versions(self.package, request)
         self.assertEqual(
-            ret, {"pkgs": {self.package.filename: {
-                'url': self.package.get_url(request),
-                'requires_python': None,
-            }}},
+            ret,
+            {
+                "pkgs": {
+                    self.package.filename: {
+                        "url": self.package.get_url(request),
+                        "requires_python": None,
+                    }
+                }
+            },
         )
         # Check the /json endpoint too
         ret = package_versions_json(self.package, request)
@@ -282,8 +287,8 @@ class PackageReadTestBase(unittest.TestCase):
             {
                 "pkgs": {
                     self.package.filename: {
-                        'url': self.package.get_url(request),
-                        'requires_python': None,
+                        "url": self.package.get_url(request),
+                        "requires_python": None,
                     },
                     f2name: self.fallback_packages[f2name],
                 }

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -125,7 +125,11 @@ class TestSimple(MockServerTest):
         self.request.app_url.assert_any_call("api", "package", name, filename)
         self.request.app_url.assert_any_call("api", "package", name, wheelname)
         self.assertEqual(
-            pkgs, {filename: self.request.app_url(), wheelname: self.request.app_url()}
+            pkgs,
+            {
+                filename: {"url": self.request.app_url()},
+                wheelname: {"url": self.request.app_url()},
+            },
         )
 
     def test_fallback_packages_redirect(self):
@@ -144,7 +148,7 @@ class TestSimple(MockServerTest):
             "urls": {version: [url, wheel_url]},
         }
         pkgs = get_fallback_packages(self.request, "foo")
-        self.assertEqual(pkgs, {filename: url, wheelname: wheel_url})
+        self.assertEqual(pkgs, {filename: {"url": url}, wheelname: {"url": wheel_url}})
 
     def test_disallow_fallback_packages(self):
         """ Disallow fetch fallback packages """
@@ -184,7 +188,10 @@ class PackageReadTestBase(unittest.TestCase):
         get = patch("pypicloud.views.simple.get_fallback_packages").start()
         p2 = self.package2
         self.fallback_packages = get.return_value = {
-            p2.filename: self.fallback_url + p2.filename
+            p2.filename: {
+                "url": self.fallback_url + p2.filename,
+                "requires_python": None,
+            },
         }
 
     def tearDown(self):
@@ -532,7 +539,10 @@ class TestCacheAlwaysShow(PackageReadTestBase):
             ret,
             {
                 "pkgs": {
-                    self.package.filename: self.package.get_url(req),
+                    self.package.filename: {
+                        "url": self.package.get_url(req),
+                        "requires_python": None,
+                    },
                     self.package2.filename: self.fallback_packages[p2.filename],
                 }
             },
@@ -548,7 +558,10 @@ class TestCacheAlwaysShow(PackageReadTestBase):
             ret,
             {
                 "pkgs": {
-                    self.package.filename: self.package.get_url(req),
+                    self.package.filename: {
+                        "url": self.package.get_url(req),
+                        "requires_python": None,
+                    },
                     self.package2.filename: self.fallback_packages[p2.filename],
                 }
             },


### PR DESCRIPTION
Store the metadata value provided by twine etc. and return it in the simple package list.