### PR TITLE
Add missing dependency "requests" to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ REQUIREMENTS = [
     "pyramid_jinja2",
     "pyramid_rpc",
     "pyramid_tm",
+    "requests",
     "six",
     "transaction",
     "zope.sqlalchemy",


### PR DESCRIPTION
9ca38db adds an import for "requests", but it is missing from `setup.py`'s `install_requires`.

Addresses #239