### PR TITLE
Drop py27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ _build
 _local.db
 *.ini
 .idea
+.mypy_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ services:
   - postgresql
   - docker
 env:
-  - TOXENV=py27
   - TOXENV=py38
   - TOXENV=lint
 matrix:

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -3,11 +3,12 @@ import calendar
 import datetime
 import logging
 import distlib.locators
+from urllib.parse import urlencode
+
 from pyramid.config import Configurator
 from pyramid.renderers import JSON, render
 from pyramid.settings import asbool
 from pyramid_beaker import session_factory_from_settings
-from six.moves.urllib.parse import urlencode  # pylint: disable=F0401,E0611
 
 from .route import Root
 from .locator import SimpleJsonLocator, FormattedScrapingLocator

--- a/pypicloud/_lambda_handler.py
+++ b/pypicloud/_lambda_handler.py
@@ -1,6 +1,4 @@
 """ AWS Lambda handler that process S3 object notifications """
-from __future__ import print_function
-
 import os
 import posixpath
 

--- a/pypicloud/access/__init__.py
+++ b/pypicloud/access/__init__.py
@@ -15,7 +15,7 @@ from .remote import RemoteAccessBackend
 from .sql import SQLAccessBackend
 
 
-def includeme(config):
+def includeme(config) -> None:
     """ Configure the app """
     settings = config.get_settings()
 

--- a/pypicloud/access/aws_secrets_manager.py
+++ b/pypicloud/access/aws_secrets_manager.py
@@ -5,12 +5,7 @@ from botocore.exceptions import ClientError
 
 from .base_json import IMutableJsonAccessBackend
 from pypicloud.util import get_settings
-
-
-try:
-    from json.decoder import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
+from json import JSONDecodeError
 
 
 class AWSSecretsManagerAccessBackend(IMutableJsonAccessBackend):

--- a/pypicloud/access/base.py
+++ b/pypicloud/access/base.py
@@ -40,7 +40,9 @@ if sys_bits < 64:
     SCHEMES.remove("pbkdf2_sha512")
 
 
-def get_pwd_context(preferred_hash: Optional[str] = None, rounds: Optional[int] = None) -> LazyCryptContext:
+def get_pwd_context(
+    preferred_hash: Optional[str] = None, rounds: Optional[int] = None
+) -> LazyCryptContext:
     """ Create a passlib context for hashing passwords """
     if preferred_hash is None or preferred_hash == "sha":
         preferred_hash = "sha256_crypt" if sys_bits < 64 else "sha512_crypt"
@@ -508,7 +510,10 @@ class IAccessBackend(object):
             user["password"] = self._get_password_hash(user["username"])
 
         data["groups"] = {}
-        packages = {"users": defaultdict(dict), "groups": defaultdict(dict)}  # type: Dict[str, Any]
+        packages = {
+            "users": defaultdict(dict),
+            "groups": defaultdict(dict),
+        }  # type: Dict[str, Any]
         for group in groups:
             data["groups"][group] = self.group_members(group)
             perms = self.group_package_permissions(group)
@@ -615,7 +620,9 @@ class IMutableAccessBackend(IAccessBackend):
             return None
         _, expected = self._hmac(username, issued)
         if hasattr(hmac, "compare_digest"):
-            if not hmac.compare_digest(signature.encode("utf-8"), expected.encode("utf-8")):
+            if not hmac.compare_digest(
+                signature.encode("utf-8"), expected.encode("utf-8")
+            ):
                 return None
         else:
             if signature != expected:
@@ -777,7 +784,9 @@ class IMutableAccessBackend(IAccessBackend):
         """
         raise NotImplementedError
 
-    def edit_user_permission(self, package: str, username: str, perm: Set[str], add: bool) -> None:
+    def edit_user_permission(
+        self, package: str, username: str, perm: Set[str], add: bool
+    ) -> None:
         """
         Grant or revoke a permission for a user on a package
 
@@ -792,7 +801,9 @@ class IMutableAccessBackend(IAccessBackend):
         """
         raise NotImplementedError
 
-    def edit_group_permission(self, package: str, group: str, perm: Set[str], add: bool) -> None:
+    def edit_group_permission(
+        self, package: str, group: str, perm: Set[str], add: bool
+    ) -> None:
         """
         Grant or revoke a permission for a group on a package
 

--- a/pypicloud/access/base.py
+++ b/pypicloud/access/base.py
@@ -1,7 +1,4 @@
 """ The access backend object base class """
-from __future__ import unicode_literals
-
-import six
 import hmac
 import hashlib
 import time
@@ -152,10 +149,10 @@ class IAccessBackend(object):
 
         """
         all_perms = {}
-        for user, perms in six.iteritems(self.user_permissions(package)):
+        for user, perms in self.user_permissions(package).items():
             all_perms["user:" + user] = tuple(perms)
 
-        for group, perms in six.iteritems(self.group_permissions(package)):
+        for group, perms in self.group_permissions(package).items():
             all_perms[group_to_principal(group)] = tuple(perms)
 
         # If there are no group or user specifications for the package, use the
@@ -179,7 +176,7 @@ class IAccessBackend(object):
         """ Construct an ACL for a package """
         acl = []
         permissions = self.allowed_permissions(package)
-        for principal, perms in six.iteritems(permissions):
+        for principal, perms in permissions.items():
             for perm in perms:
                 acl.append((Allow, principal, perm))
         return acl
@@ -617,9 +614,9 @@ class IMutableAccessBackend(IAccessBackend):
             return None
         _, expected = self._hmac(username, issued)
         if hasattr(hmac, "compare_digest"):
-            if isinstance(signature, six.text_type):
+            if isinstance(signature, str):
                 signature = signature.encode("utf-8")
-            if isinstance(expected, six.text_type):
+            if isinstance(expected, str):
                 expected = expected.encode("utf-8")
             if not hmac.compare_digest(signature, expected):
                 return None
@@ -835,7 +832,7 @@ class IMutableAccessBackend(IAccessBackend):
                 self.approve_user(user["username"])
             self.set_user_admin(user["username"], user.get("admin", False))
 
-        for group, members in six.iteritems(data["groups"]):
+        for group, members in data["groups"].items():
             if not self.group_members(group):
                 self.create_group(group)
             current_members = self.group_members(group)
@@ -847,13 +844,13 @@ class IMutableAccessBackend(IAccessBackend):
             if not user_exists(user["username"]):
                 self._register(user["username"], user["password"])
 
-        for package, groups in six.iteritems(data["packages"]["groups"]):
-            for group, permissions in six.iteritems(groups):
+        for package, groups in data["packages"]["groups"].items():
+            for group, permissions in groups.items():
                 for perm in permissions:
                     self.edit_group_permission(package, group, perm, True)
 
-        for package, users in six.iteritems(data["packages"]["users"]):
-            for user, permissions in six.iteritems(users):
+        for package, users in data["packages"]["users"].items():
+            for user, permissions in users.items():
                 for perm in permissions:
                     self.edit_user_permission(package, user, perm, True)
 

--- a/pypicloud/access/config.py
+++ b/pypicloud/access/config.py
@@ -1,6 +1,5 @@
 """ Backend that reads access control rules from config file """
 import logging
-import six
 from pyramid.settings import aslist
 
 from .base_json import IJsonAccessBackend
@@ -23,7 +22,7 @@ class ConfigAccessBackend(IJsonAccessBackend):
         data = {}
 
         users = {}
-        for key, value in six.iteritems(settings):
+        for key, value in settings.items():
             if not key.startswith("user."):
                 continue
             users[key[len("user.") :]] = value
@@ -32,14 +31,14 @@ class ConfigAccessBackend(IJsonAccessBackend):
         data["admins"] = aslist(settings.get("auth.admins", []))
 
         groups = {}
-        for key, value in six.iteritems(settings):
+        for key, value in settings.items():
             if not key.startswith("group."):
                 continue
             groups[key[len("group.") :]] = aslist(value)
         data["groups"] = groups
 
         packages = {}
-        for key, value in six.iteritems(settings):
+        for key, value in settings.items():
             pieces = key.split(".")
             if len(pieces) != 4 or pieces[0] != "package":
                 continue
@@ -83,7 +82,7 @@ class ConfigAccessBackend(IJsonAccessBackend):
             for admin in admins:
                 lines.append("    {0}".format(admin))
 
-        for group, members in six.iteritems(data["groups"]):
+        for group, members in data["groups"].items():
             lines.append("group.{0} =".format(group))
             for member in members:
                 lines.append("    {0}".format(member))
@@ -97,16 +96,16 @@ class ConfigAccessBackend(IJsonAccessBackend):
                 ret += "w"
             return ret
 
-        for package, groups in six.iteritems(data["packages"]["groups"]):
-            for group, permissions in six.iteritems(groups):
+        for package, groups in data["packages"]["groups"].items():
+            for group, permissions in groups.items():
                 lines.append(
                     "package.{0}.group.{1} = {2}".format(
                         package, group, encode_permissions(permissions)
                     )
                 )
 
-        for package, users in six.iteritems(data["packages"]["users"]):
-            for user, permissions in six.iteritems(users):
+        for package, users in data["packages"]["users"].items():
+            for user, permissions in users.items():
                 lines.append(
                     "package.{0}.user.{1} = {2}".format(
                         package, user, encode_permissions(permissions)

--- a/pypicloud/access/ldap_.py
+++ b/pypicloud/access/ldap_.py
@@ -1,5 +1,4 @@
 """LDAP authentication plugin for pypicloud."""
-from __future__ import unicode_literals
 import logging
 from collections import namedtuple
 from functools import wraps

--- a/pypicloud/access/sql.py
+++ b/pypicloud/access/sql.py
@@ -228,6 +228,7 @@ class SQLAccessBackend(IMutableAccessBackend):
     def group_permissions(self, package):
         query = self.db.query(GroupPermission).filter_by(package=package)
         perms = {}
+
         for perm in query:
             perms[perm.groupname] = perm.permissions
         return perms

--- a/pypicloud/cache/dynamo.py
+++ b/pypicloud/cache/dynamo.py
@@ -1,6 +1,5 @@
 """ Store package data in DynamoDB """
 import logging
-import six
 from collections import defaultdict
 from datetime import datetime
 from dynamo3 import DynamoDBConnection
@@ -220,7 +219,7 @@ class DynamoCache(ICache):
         summaries_by_name = {}
         for summary in summaries:
             summaries_by_name[summary.name] = summary
-        for name, packages in six.iteritems(packages_by_name):
+        for name, packages in packages_by_name.items():
             if name in summaries_by_name:
                 summary = summaries_by_name[name]
             else:
@@ -247,6 +246,6 @@ class DynamoCache(ICache):
         try:
             self.engine.scan(PackageSummary).first()
         except Exception as e:
-            return (False, str(e))
+            return False, str(e)
         else:
-            return (True, "")
+            return True, ""

--- a/pypicloud/cache/redis_cache.py
+++ b/pypicloud/cache/redis_cache.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import calendar
 import json
 import logging
-import six
 from collections import defaultdict
 from datetime import datetime
 from pyramid.settings import asbool
@@ -86,7 +85,7 @@ class RedisCache(ICache):
         summary = data.pop("summary")
         if summary == "":
             summary = None
-        kwargs = dict(((k, json.loads(v)) for k, v in six.iteritems(data)))
+        kwargs = dict(((k, json.loads(v)) for k, v in data.items()))
         return self.package_class(
             name, version, filename, last_modified, summary, **kwargs
         )
@@ -167,7 +166,7 @@ class RedisCache(ICache):
             "last_modified": last_modified,
             "summary": package.summary or "",
         }
-        for key, value in six.iteritems(package.data):
+        for key, value in package.data.items():
             data[key] = json.dumps(value)
         pipe.hmset(self.redis_key(package.filename), data)
         pipe.sadd(self.redis_set, package.name)
@@ -267,7 +266,7 @@ class RedisCache(ICache):
         summaries_by_name = {}
         for summary in summaries:
             summaries_by_name[summary["name"]] = summary
-        for name, packages in six.iteritems(packages_by_name):
+        for name, packages in packages_by_name.items():
             if name in summaries_by_name:
                 summary = summaries_by_name[name]
             else:

--- a/pypicloud/cache/redis_cache.py
+++ b/pypicloud/cache/redis_cache.py
@@ -1,6 +1,4 @@
 """ Store package data in redis """
-from __future__ import unicode_literals
-
 import calendar
 import json
 import logging
@@ -10,11 +8,6 @@ from pyramid.settings import asbool
 
 from .base import ICache
 
-
-try:
-    from itertools import izip
-except ImportError:  # pragma: no cover
-    izip = zip  # pylint: disable=C0103
 
 LOG = logging.getLogger(__name__)
 
@@ -295,7 +288,7 @@ class RedisCache(ICache):
                 pipe.scard(self.redis_filename_set(name))
             counts = pipe.execute()
             pipe = self.db.pipeline()
-            for name, count in izip(removed, counts):
+            for name, count in zip(removed, counts):
                 if count == 0:
                     self._delete_summary(name, pipe)
             pipe.execute()

--- a/pypicloud/lambda_scripts.py
+++ b/pypicloud/lambda_scripts.py
@@ -1,21 +1,18 @@
 """ Helpers for syncing packages into the cache in AWS Lambda """
-from __future__ import print_function
-
 import os
 import sys
 from distutils.spawn import find_executable  # pylint: disable=E0611,F0401
+from urllib.request import urlretrieve
 
 import argparse
 import boto3
 import json
 import logging
 import shutil
-import six
 import subprocess
 import tempfile
 import zipfile
 from pyramid.paster import get_appsettings
-from six.moves.urllib.request import urlretrieve  # pylint: disable=E0611,F0401
 
 from pypicloud import __version__, _lambda_handler
 from pypicloud.storage.s3 import S3Storage
@@ -323,7 +320,7 @@ def create_sync_scripts(argv=None):
         handler_module = os.path.splitext(HANDLER_FILENAME)[0]
         # Pull out only the cache db settings
         small_settings = {"pypi.db": settings["pypi.db"]}
-        for key, val in six.iteritems(settings):
+        for key, val in settings.items():
             if key.startswith("db."):
                 small_settings[key] = val
 

--- a/pypicloud/models.py
+++ b/pypicloud/models.py
@@ -2,7 +2,6 @@
 import re
 
 import pkg_resources
-import six
 from datetime import datetime
 from functools import total_ordering
 
@@ -12,7 +11,6 @@ from .util import normalize_name
 METADATA_FIELDS = ["requires_python", "summary"]
 
 
-@six.python_2_unicode_compatible
 @total_ordering
 class Package(object):
 
@@ -99,7 +97,7 @@ class Package(object):
         return self.__str__()
 
     def __str__(self):
-        return u"Package(%s)" % (self.filename)
+        return "Package(%s)" % self.filename
 
     def __json__(self, request):
         return {

--- a/pypicloud/models.py
+++ b/pypicloud/models.py
@@ -29,7 +29,7 @@ class Package(object):
         The datetime when this package was uploaded (default now)
     summary : str, optional
         The summary of the package
-    **kwargs : dict
+    **kwargs :
         Metadata about the package
 
     """

--- a/pypicloud/route.py
+++ b/pypicloud/route.py
@@ -1,5 +1,6 @@
 """ Tools and resources for traversal routing """
 import functools
+from typing import Dict, Callable, Any
 
 
 class IStaticResource(object):
@@ -8,7 +9,7 @@ class IStaticResource(object):
 
     __name__ = ""
     __parent__ = None
-    subobjects = {}
+    subobjects = {}  # type: Dict[str, Callable[[Any], Any]]
 
     def __init__(self, request):
         self.request = request

--- a/pypicloud/scripts.py
+++ b/pypicloud/scripts.py
@@ -1,6 +1,5 @@
 """ Commandline scripts """
 import sys
-import six
 
 import argparse
 import getpass
@@ -30,7 +29,7 @@ def gen_password(argv=None):
         choices=SCHEMES,
     )
     args = parser.parse_args(argv)
-    six.print_(_gen_password(args.s, args.r))
+    print(_gen_password(args.s, args.r))
 
 
 def _gen_password(scheme=None, rounds=None):
@@ -42,7 +41,7 @@ def _gen_password(scheme=None, rounds=None):
         if password == verify:
             return pwd_context.hash(password)
         else:
-            six.print_("Passwords do not match!")
+            print("Passwords do not match!")
 
 
 NO_DEFAULT = object()
@@ -50,7 +49,7 @@ NO_DEFAULT = object()
 
 def wrapped_input(msg):
     """ Wraps input for tests """
-    return six.moves.input(msg)
+    return input(msg)
 
 
 def prompt(msg, default=NO_DEFAULT, validate=None):
@@ -69,13 +68,13 @@ def prompt_option(text, choices, default=NO_DEFAULT):
     """ Prompt the user to choose one of a list of options """
     while True:
         for i, msg in enumerate(choices):
-            six.print_("[%d] %s" % (i + 1, msg))
+            print("[%d] %s" % (i + 1, msg))
         response = prompt(text, default=default)
         try:
             idx = int(response) - 1
             return choices[idx]
         except (ValueError, IndexError):
-            six.print_("Invalid choice\n")
+            print("Invalid choice\n")
 
 
 def promptyn(msg, default=None):
@@ -98,13 +97,13 @@ def promptyn(msg, default=None):
 def bucket_validate(name):
     """ Check for valid bucket name """
     if name.startswith("."):
-        six.print_("Bucket names cannot start with '.'")
+        print("Bucket names cannot start with '.'")
         return False
     if name.endswith("."):
-        six.print_("Bucket names cannot end with '.'")
+        print("Bucket names cannot end with '.'")
         return False
     if ".." in name:
-        six.print_("Bucket names cannot contain '..'")
+        print("Bucket names cannot contain '..'")
         return False
     return True
 
@@ -112,7 +111,7 @@ def bucket_validate(name):
 def storage_account_name_validate(name):
     """ Check for valid storage account name """
     if "." in name:
-        six.print_("Storage account names cannot contain '.'")
+        print("Storage account names cannot contain '.'")
         return False
     return True
 
@@ -224,7 +223,7 @@ def make_config(argv=None):
         with open(args.outfile, "w") as ofile:
             ofile.write(config_file)
 
-        six.print_("Config file written to '%s'" % args.outfile)
+        print("Config file written to '%s'" % args.outfile)
 
 
 def migrate_packages(argv=None):
@@ -259,7 +258,7 @@ def migrate_packages(argv=None):
     new_env = bootstrap(args.config_to)
     new_storage = new_env["request"].db.storage
     for package in all_packages:
-        six.print_("Migrating %s" % package)
+        print("Migrating %s" % package)
         with old_storage.open(package) as data:
             # we need to recalculate the path for the new storage config
             package.data.pop("path", None)
@@ -284,7 +283,7 @@ def export_access(argv=None):
         with gzip.open(args.o, "w") as ofile:
             json.dump(data, ofile)
     else:
-        six.print_(json.dumps(data, indent=2))
+        print(json.dumps(data, indent=2))
 
 
 def import_access(argv=None):
@@ -311,7 +310,7 @@ def import_access(argv=None):
         with gzip.open(args.i, "r") as ifile:
             data = json.load(ifile)
     else:
-        six.print_("Reading data from stdin...")
+        print("Reading data from stdin...")
         data = json.load(sys.stdin)
 
     env = bootstrap(args.config)
@@ -319,4 +318,4 @@ def import_access(argv=None):
     result = access.load(data)
     transaction.commit()
     if result is not None:
-        six.print_(result)
+        print(result)

--- a/pypicloud/storage/__init__.py
+++ b/pypicloud/storage/__init__.py
@@ -1,5 +1,6 @@
 """ Storage backend implementations """
 from functools import partial
+from typing import Callable, Any
 
 from .base import IStorage
 from .files import FileStorage
@@ -22,7 +23,7 @@ except ImportError:
     AZURE_BLOB_IS_AVAILABLE = False
 
 
-def get_storage_impl(settings):
+def get_storage_impl(settings) -> Callable[[Any], Any]:
     """ Get and configure the storage backend wrapper """
     resolver = DottedNameResolver(__name__)
     storage = settings.get("pypi.storage", "file")

--- a/pypicloud/storage/azure_blob.py
+++ b/pypicloud/storage/azure_blob.py
@@ -2,6 +2,8 @@
 from __future__ import unicode_literals
 import logging
 import posixpath
+from io import BytesIO
+from urllib.request import urlopen
 from datetime import datetime, timedelta
 from contextlib import contextmanager
 
@@ -9,8 +11,6 @@ from azure.storage.blob import BlobServiceClient, BlobSasPermissions, generate_b
 from azure.core.exceptions import ResourceNotFoundError
 from pyramid.httpexceptions import HTTPFound
 from pyramid.settings import asbool
-from six import BytesIO
-from six.moves.urllib.request import urlopen  # pylint: disable=F0401,E0611
 
 from .base import IStorage
 from pypicloud.models import Package

--- a/pypicloud/storage/azure_blob.py
+++ b/pypicloud/storage/azure_blob.py
@@ -1,5 +1,4 @@
 """ Store packages in Azure Blob Storage """
-from __future__ import unicode_literals
 import logging
 import posixpath
 from io import BytesIO
@@ -76,7 +75,7 @@ class AzureBlobStorage(IStorage):
 
         return kwargs
 
-    def _generate_url(self, package):
+    def _generate_url(self, package: Package) -> str:
         path = self.get_path(package)
 
         url_params = generate_blob_sas(

--- a/pypicloud/storage/base.py
+++ b/pypicloud/storage/base.py
@@ -1,4 +1,5 @@
 """ Base class for storage backends """
+from typing import Type, List, BinaryIO, Tuple
 from pypicloud.models import Package
 
 
@@ -14,11 +15,11 @@ class IStorage(object):
         """ Configure the storage method with app settings """
         return {}
 
-    def list(self, factory=Package):
+    def list(self, factory: Type[Package] = Package) -> List[Package]:
         """ Return a list or generator of all packages """
         raise NotImplementedError
 
-    def get_url(self, package):
+    def get_url(self, package: Package) -> str:
         """
         Create or return an HTTP url for a package file
 
@@ -34,7 +35,7 @@ class IStorage(object):
         """
         return self.request.app_url("api", "package", package.name, package.filename)
 
-    def download_response(self, package):
+    def download_response(self, package: Package):
         """
         Return a HTTP Response that will download this package
 
@@ -43,7 +44,7 @@ class IStorage(object):
         """
         raise NotImplementedError
 
-    def upload(self, package, datastream):
+    def upload(self, package: Package, datastream: BinaryIO) -> None:
         """
         Upload a package file to the storage backend
 
@@ -57,7 +58,7 @@ class IStorage(object):
         """
         raise NotImplementedError
 
-    def delete(self, package):
+    def delete(self, package: Package) -> None:
         """
         Delete a package file
 
@@ -69,7 +70,7 @@ class IStorage(object):
         """
         raise NotImplementedError
 
-    def open(self, package):
+    def open(self, package: Package):
         """
         Get a buffer object that can read the package data
 
@@ -91,7 +92,7 @@ class IStorage(object):
         """
         raise NotImplementedError
 
-    def check_health(self):
+    def check_health(self) -> Tuple[bool, str]:
         """
         Check the health of the storage backend
 

--- a/pypicloud/storage/base.py
+++ b/pypicloud/storage/base.py
@@ -102,4 +102,4 @@ class IStorage(object):
             status message
 
         """
-        return (True, "")
+        return True, ""

--- a/pypicloud/storage/object_store.py
+++ b/pypicloud/storage/object_store.py
@@ -1,5 +1,7 @@
 """ Store packages in S3 """
 from binascii import hexlify
+from io import BytesIO
+from urllib.request import urlopen
 
 import logging
 
@@ -7,8 +9,6 @@ from contextlib import contextmanager
 from hashlib import md5
 from pyramid.settings import asbool
 from pyramid.httpexceptions import HTTPFound
-from six.moves.urllib.request import urlopen  # pylint: disable=F0401,E0611
-from six import BytesIO
 
 from .base import IStorage
 

--- a/pypicloud/storage/object_store.py
+++ b/pypicloud/storage/object_store.py
@@ -11,6 +11,7 @@ from pyramid.settings import asbool
 from pyramid.httpexceptions import HTTPFound
 
 from .base import IStorage
+from pypicloud.models import Package
 
 
 LOG = logging.getLogger(__name__)
@@ -52,13 +53,13 @@ class ObjectStoreStorage(IStorage):
         self.public_url = public_url
 
     @classmethod
-    def get_bucket(cls, bucket_name, settings):
+    def get_bucket(cls, bucket_name: str, settings):
         """ Subclasses must implement a method for generating a Bucket class
             instance in the backend's SDK
         """
         raise NotImplementedError
 
-    def _generate_url(self, package):
+    def _generate_url(self, package: Package) -> str:
         """ Subclasses must implement a method for generating signed URLs to
             the package in the object store
         """

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -1,6 +1,6 @@
 """ Store packages in S3 """
-from __future__ import unicode_literals
 import posixpath
+from urllib.parse import urlparse, quote
 
 import boto3
 import logging
@@ -16,7 +16,6 @@ from cryptography.hazmat.primitives import hashes
 from datetime import datetime, timedelta
 from pyramid.settings import asbool, falsey
 from pyramid_duh.settings import asdict
-from six.moves.urllib.parse import urlparse, quote  # pylint: disable=F0401,E0611
 
 from .object_store import ObjectStoreStorage
 from pypicloud.models import Package

--- a/pypicloud/util.py
+++ b/pypicloud/util.py
@@ -123,7 +123,9 @@ class TimedCache(dict):
 
     """
 
-    def __init__(self, cache_time: Optional[int], factory: Optional[Callable[[Any], Any]] = None):
+    def __init__(
+        self, cache_time: Optional[int], factory: Optional[Callable[[Any], Any]] = None
+    ):
         super(TimedCache, self).__init__()
         if cache_time is not None and cache_time < 0:
             raise ValueError("cache_time cannot be negative")

--- a/pypicloud/util.py
+++ b/pypicloud/util.py
@@ -2,6 +2,7 @@
 import re
 import time
 import unicodedata
+from typing import Dict, Union, Optional, Tuple, Callable, List, Any
 
 import logging
 from distlib.locators import Locator
@@ -14,7 +15,7 @@ ALL_EXTENSIONS = Locator.source_extensions + Locator.binary_extensions
 SENTINEL = object()
 
 
-def parse_filename(filename, name=None):
+def parse_filename(filename: str, name: Optional[str] = None) -> Tuple[str, str]:
     """ Parse a name and version out of a filename """
     version = None
     for ext in ALL_EXTENSIONS:
@@ -36,14 +37,14 @@ def parse_filename(filename, name=None):
     return normalize_name(name), version
 
 
-def normalize_name(name):
+def normalize_name(name: str) -> str:
     """ Normalize a python package name """
     # Lifted directly from PEP503:
     # https://www.python.org/dev/peps/pep-0503/#id4
     return re.sub(r"[-_.]+", "-", name).lower()
 
 
-def normalize_metadata(metadata):
+def normalize_metadata(metadata: Dict[str, Union[str, bytes]]) -> None:
     """Strip non-ASCII characters from metadata"""
     for key, value in metadata.items():
         if isinstance(value, bytes):
@@ -55,7 +56,7 @@ def normalize_metadata(metadata):
             )
 
 
-def create_matcher(queries, query_type):
+def create_matcher(queries: List[str], query_type: str) -> Callable[[str], bool]:
     """
     Create a matcher for a list of queries
 
@@ -79,7 +80,7 @@ def create_matcher(queries, query_type):
         return lambda x: all((q in x.lower() for q in queries))
 
 
-def get_settings(settings, prefix, **kwargs):
+def get_settings(settings: dict, prefix: str, **kwargs) -> dict:
     """
     Convenience method for fetching settings
 
@@ -122,13 +123,13 @@ class TimedCache(dict):
 
     """
 
-    def __init__(self, cache_time, factory=None):
+    def __init__(self, cache_time: Optional[int], factory: Optional[Callable[[Any], Any]] = None):
         super(TimedCache, self).__init__()
         if cache_time is not None and cache_time < 0:
             raise ValueError("cache_time cannot be negative")
         self._cache_time = cache_time
         self._factory = factory
-        self._times = {}
+        self._times = {}  # type: Dict[str, float]
 
     def _has_expired(self, key):
         """ Check if a key is both present and expired """

--- a/pypicloud/util.py
+++ b/pypicloud/util.py
@@ -4,7 +4,6 @@ import time
 import unicodedata
 
 import logging
-import six
 from distlib.locators import Locator
 from distlib.util import split_filename
 from distlib.wheel import Wheel
@@ -47,9 +46,10 @@ def normalize_name(name):
 def normalize_metadata(metadata):
     """Strip non-ASCII characters from metadata"""
     for key, value in metadata.items():
-        if isinstance(value, six.string_types):
-            if isinstance(value, six.binary_type):
-                value = value.decode("utf-8")
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+
+        if isinstance(value, str):
             metadata[key] = "".join(
                 c for c in unicodedata.normalize("NFKD", value) if ord(c) < 128
             )
@@ -98,7 +98,7 @@ def get_settings(settings, prefix, **kwargs):
 
     """
     computed = {}
-    for name, fxn in six.iteritems(kwargs):
+    for name, fxn in kwargs.items():
         val = settings.get(prefix + name)
         if val is not None:
             computed[name] = fxn(val)

--- a/pypicloud/views/admin.py
+++ b/pypicloud/views/admin.py
@@ -1,7 +1,7 @@
 """ API endpoints for admin controls """
 import gzip
 import json
-import six
+from io import BytesIO
 from paste.httpheaders import CONTENT_DISPOSITION  # pylint: disable=E0611
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.response import FileIter
@@ -129,13 +129,11 @@ class AdminEndpoints(object):
         package = self.request.named_subpaths["package"]
         user_perms = [
             {"username": key, "permissions": val}
-            for key, val in six.iteritems(self.request.access.user_permissions(package))
+            for key, val in self.request.access.user_permissions(package).items()
         ]
         group_perms = [
             {"group": key, "permissions": val}
-            for key, val in six.iteritems(
-                self.request.access.group_permissions(package)
-            )
+            for key, val in self.request.access.group_permissions(package).items()
         ]
         return {"user": user_perms, "group": group_perms}
 
@@ -184,7 +182,7 @@ class AdminEndpoints(object):
     def download_access_control(self):
         """ Download the ACL data as a gzipped-json file """
         data = self.request.access.dump()
-        compressed = six.BytesIO()
+        compressed = BytesIO()
         zipfile = gzip.GzipFile(mode="wb", fileobj=compressed)
         zipfile.write(json.dumps(data, separators=(",", ":")).encode("utf8"))
         zipfile.close()

--- a/pypicloud/views/api.py
+++ b/pypicloud/views/api.py
@@ -2,8 +2,9 @@
 import posixpath
 
 import logging
-import six
+from io import BytesIO
 from contextlib import closing
+from urllib.request import urlopen
 
 # pylint: disable=E0611,W0403
 from paste.httpheaders import CONTENT_DISPOSITION, CACHE_CONTROL
@@ -13,7 +14,6 @@ from pyramid.httpexceptions import HTTPNotFound, HTTPForbidden, HTTPBadRequest
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
 from pyramid_duh import argify, addslash
-from six.moves.urllib.request import urlopen  # pylint: disable=F0401,E0611
 
 from .login import handle_register_request
 from pypicloud.route import (
@@ -42,7 +42,7 @@ def all_packages(request, verbose=False):
     i = 0
     while i < len(packages):
         package = packages[i]
-        name = package if isinstance(package, six.string_types) else package["name"]
+        name = package if isinstance(package, str) else package["name"]
         if not request.access.has_permission(name, "read"):
             del packages[i]
             continue
@@ -77,7 +77,7 @@ def fetch_dist(request, url, name, version, summary, requires_python):
     # TODO: digest validation
     return (
         request.db.upload(
-            filename, six.BytesIO(data), name, version, summary, requires_python
+            filename, BytesIO(data), name, version, summary, requires_python
         ),
         data,
     )

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -3,7 +3,6 @@ import posixpath
 
 import pkg_resources
 import logging
-import six
 from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPNotFound, HTTPConflict
 from pyramid.view import view_config
 from pyramid_duh import argify, addslash
@@ -122,7 +121,7 @@ def package_versions_json(context, request):
         return pkgs
     response = {"info": {"name": context.name}, "releases": {}}
     max_version = None
-    for filename, pkg in six.iteritems(pkgs["pkgs"]):
+    for filename, pkg in pkgs["pkgs"].items():
         name, version_str = parse_filename(filename)
         version = pkg_resources.parse_version(version_str)
         if max_version is None or version > max_version:
@@ -221,7 +220,7 @@ def _simple_redirect_always_show(context, request):
             pkgs = get_fallback_packages(request, context.name)
             stored_pkgs = packages_to_dict(request, packages)
             # Overwrite existing package urls
-            for filename, url in six.iteritems(stored_pkgs):
+            for filename, url in stored_pkgs.items():
                 pkgs[filename] = url
             return _pkg_response(pkgs)
     else:
@@ -269,7 +268,7 @@ def _simple_cache_always_show(context, request):
                 pkgs = get_fallback_packages(request, context.name)
                 stored_pkgs = packages_to_dict(request, packages)
                 # Overwrite existing package urls
-                for filename, data in six.iteritems(stored_pkgs):
+                for filename, data in stored_pkgs.items():
                     pkgs[filename] = data
                 return _pkg_response(pkgs)
             else:
@@ -278,7 +277,7 @@ def _simple_cache_always_show(context, request):
             pkgs = get_fallback_packages(request, context.name, False)
             stored_pkgs = packages_to_dict(request, packages)
             # Overwrite existing package urls
-            for filename, data in six.iteritems(stored_pkgs):
+            for filename, data in stored_pkgs.items():
                 pkgs[filename] = data
             return _pkg_response(pkgs)
     else:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,5 @@
 bumpversion
 tox
 wheel
+mypy
+sqlalchemy-stubs

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ universal = 1
 
 [pycodestyle]
 ignore=E,W
+
+[mypy]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ REQUIREMENTS = [
     "pyramid_rpc",
     "pyramid_tm",
     "requests",
-    "six",
     "transaction",
     "zope.sqlalchemy",
 ]
@@ -66,8 +65,6 @@ if __name__ == "__main__":
         long_description=README + "\n\n" + CHANGES,
         classifiers=[
             "Programming Language :: Python",
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
@@ -88,6 +85,7 @@ if __name__ == "__main__":
         keywords="pypi s3 cheeseshop package",
         platforms="any",
         zip_safe=False,
+        python_requires=">=3.5",
         include_package_data=True,
         packages=find_packages(exclude=("tests",)),
         entry_points={

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,5 @@
 """ Tests for pypicloud """
-from __future__ import unicode_literals
-
 import os
-import six
 import unittest
 from collections import defaultdict
 from datetime import datetime
@@ -15,8 +12,7 @@ from pypicloud.models import Package
 from pypicloud.storage import IStorage
 
 
-if six.PY3:
-    unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
+unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
 
 
 os.environ["AWS_SECRET_ACCESS_KEY"] = "access_key"
@@ -68,7 +64,7 @@ class DummyStorage(IStorage):
 
     def list(self, factory=Package):
         """ Return a list or generator of all packages """
-        for args in six.itervalues(self.packages):
+        for args in self.packages.values():
             yield args[0]
 
     def download_response(self, package):
@@ -99,11 +95,11 @@ class DummyCache(ICache):
 
     def all(self, name):
         """ Override this method to implement 'all' """
-        return [p for p in six.itervalues(self.packages) if p.name == name]
+        return [p for p in self.packages.values() if p.name == name]
 
     def distinct(self):
         """ Get all distinct package names """
-        return list(set((p.name for p in six.itervalues(self.packages))))
+        return list(set((p.name for p in self.packages.values())))
 
     def clear(self, package):
         """ Remove this package from the caching database """

--- a/tests/test_access_backends.py
+++ b/tests/test_access_backends.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 """ Tests for access backends """
-from __future__ import unicode_literals
-
-import six
 import json
 import ldap
 import transaction
@@ -1152,7 +1149,7 @@ class TestSQLiteBackend(unittest.TestCase):
             """ Assertion that handles unordered lists inside dicts """
             if isinstance(obj1, dict):
                 self.assertEqual(len(obj1), len(obj2))
-                for key, val in six.iteritems(obj1):
+                for key, val in obj1.items():
                     assert_nice_equals(val, obj2[key])
             elif isinstance(obj1, list):
                 self.assertItemsEqual(obj1, obj2)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,4 @@
 """ Tests for auth methods """
-from __future__ import unicode_literals
-
 from base64 import b64encode
 from mock import MagicMock, patch
 from pyramid.security import Everyone

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """ Tests for database cache implementations """
-from __future__ import unicode_literals
-
 import calendar
 import transaction
 import unittest

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,14 +1,9 @@
 """ Tests for commandline scripts """
+import unittest
 from mock import patch
 
 from pypicloud import scripts
 from pypicloud.access import get_pwd_context
-
-
-try:
-    import unittest2 as unittest  # pylint: disable=F0401
-except ImportError:
-    import unittest
 
 
 class TestScripts(unittest.TestCase):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,5 +1,4 @@
 """ Tests for view security and auth """
-import six
 import base64
 import webtest
 from collections import defaultdict
@@ -7,12 +6,7 @@ from passlib.hash import sha256_crypt  # pylint: disable=E0611
 
 from . import DummyCache, DummyStorage, make_package
 from pypicloud import main
-
-
-try:
-    import unittest2 as unittest  # pylint: disable=F0401
-except ImportError:
-    import unittest
+import unittest
 
 # pylint: disable=W0212
 
@@ -25,8 +19,7 @@ def _auth(username, password):
         .replace("\n", "")
     )
     header = "Basic " + base64string
-    if six.PY2:
-        header = header.encode("utf8")
+
     return {"Authorization": header}
 
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,7 +1,6 @@
 """ Unit tests for the simple endpoints """
-import six
-
 from mock import MagicMock, patch
+from types import MethodType
 
 from . import MockServerTest, make_package, make_dist
 from pypicloud.auth import _request_login
@@ -13,12 +12,7 @@ from pypicloud.views.simple import (
     package_versions_json,
     get_fallback_packages,
 )
-
-
-try:
-    import unittest2 as unittest  # pylint: disable=F0401
-except ImportError:
-    import unittest
+import unittest
 
 
 class TestSimple(MockServerTest):
@@ -221,7 +215,7 @@ class PackageReadTestBase(unittest.TestCase):
         request.access.can_update_cache = lambda: "c" in perms
         request.access.has_permission.side_effect = lambda n, p: "r" in perms
         request.is_logged_in = user is not None
-        request.request_login = six.create_bound_method(_request_login, request)
+        request.request_login = MethodType(_request_login, request)
         pkgs = []
         if package is not None:
             pkgs.append(package)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,13 +4,13 @@ import json
 import time
 import datetime
 import sys
-from six import BytesIO
+from io import BytesIO
+from urllib.parse import urlparse, parse_qs
 
 import shutil
 import tempfile
 from mock import MagicMock, patch, ANY
 from moto import mock_s3
-from six.moves.urllib.parse import urlparse, parse_qs  # pylint: disable=F0401,E0611
 
 import boto3
 import os
@@ -26,11 +26,7 @@ from pypicloud.storage import (
     get_storage_impl,
 )
 from . import make_package
-
-try:
-    import unittest2 as unittest  # pylint: disable=F0401
-except ImportError:
-    import unittest
+import unittest
 
 
 class TestS3Storage(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, lint
+envlist = py35, py36, py37, py38, lint
 
 [testenv]
 deps =


### PR DESCRIPTION
Drops Python 2.7 and adds some basic type hints where its easy to do so.

Probably best off looking at the diff's between the individual commits.

Might want to look at running `isort` to sort the imports at some point in the future