### PR TITLE
Added package hashing logic

### DIFF
--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -98,6 +98,15 @@ Only used when ``pypi.fallback = cache``. This is
 the list of groups that are allowed to trigger the operation that fetches
 packages from ``fallback_base_url``.  (default ['authenticated'])
 
+``pypi.calculate_package_hashes``
+**Argument:** bool, optional
+
+Package SHA256 and MD5 hashes are now calculated by default when a package is
+uploaded. This option enables or disables the hash calculation (default true)
+
+Scripts to calculate hashes on existing packages exist here:
+https://github.com/stevearc/pypicloud/tree/master/scripts
+
 ``pypi.allow_overwrite``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 **Argument:** bool, optional

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -23,14 +23,16 @@ def to_json(value):
     return render("json", value)
 
 
-def _app_url(request, *paths, **params):
+def _app_url(request, *paths, fragment="", **params):
     """ Get the base url for the root of the app plus an optional path """
     path = "/".join(paths)
     if not path.startswith("/"):
         path = "/" + path
     if params:
         path += "?" + urlencode(params)
-    return request.application_url + path
+    if fragment:
+        fragment = "#" + fragment
+    return request.application_url + path + fragment
 
 
 def _fallback_simple(request):

--- a/pypicloud/access/base.py
+++ b/pypicloud/access/base.py
@@ -46,7 +46,7 @@ def get_pwd_context(
     """ Create a passlib context for hashing passwords """
     if preferred_hash is None or preferred_hash == "sha":
         preferred_hash = "sha256_crypt" if sys_bits < 64 else "sha512_crypt"
-    if preferred_hash is "pbkdf2":
+    if preferred_hash == "pbkdf2":
         preferred_hash = "pbkdf2_sha256" if sys_bits < 64 else "pbkdf2_sha512"
 
     if preferred_hash not in SCHEMES:

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -18,8 +18,6 @@ class ICache(object):
 
     """ Base class for a caching database that stores package metadata """
 
-    package_class = Package
-
     def __init__(
         self, request=None, storage=None, allow_overwrite=None, calculate_hashes=True
     ):
@@ -28,7 +26,7 @@ class ICache(object):
         self.allow_overwrite = allow_overwrite
         self.calculate_hashes = calculate_hashes
 
-    def new_package(self, *args, **kwargs):
+    def new_package(self, *args, **kwargs) -> Package:
         return Package(*args, **kwargs)
 
     def reload_if_needed(self) -> None:
@@ -139,7 +137,7 @@ class ICache(object):
             metadata["hash_md5"] = hashlib.md5(file_data).hexdigest()
             data = BytesIO(file_data)
 
-        new_pkg = self.package_class(
+        new_pkg = self.new_package(
             name, version, filename, summary=summary, **metadata
         )
         self.storage.upload(new_pkg, data)

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -137,9 +137,7 @@ class ICache(object):
             metadata["hash_md5"] = hashlib.md5(file_data).hexdigest()
             data = BytesIO(file_data)
 
-        new_pkg = self.new_package(
-            name, version, filename, summary=summary, **metadata
-        )
+        new_pkg = self.new_package(name, version, filename, summary=summary, **metadata)
         self.storage.upload(new_pkg, data)
         self.save(new_pkg)
         return new_pkg

--- a/pypicloud/models.py
+++ b/pypicloud/models.py
@@ -8,7 +8,7 @@ from functools import total_ordering
 from .util import normalize_name
 
 
-METADATA_FIELDS = ["requires_python", "summary"]
+METADATA_FIELDS = ["requires_python", "summary", "hash_sha256", "hash_md5"]
 
 
 @total_ordering

--- a/pypicloud/storage/base.py
+++ b/pypicloud/storage/base.py
@@ -1,4 +1,5 @@
 """ Base class for storage backends """
+from pyramid.request import Request
 from typing import Type, List, BinaryIO, Tuple
 from pypicloud.models import Package
 
@@ -7,7 +8,7 @@ class IStorage(object):
 
     """ Base class for a backend that stores package files """
 
-    def __init__(self, request):
+    def __init__(self, request: Request):
         self.request = request
 
     @classmethod
@@ -33,7 +34,12 @@ class IStorage(object):
             Link to the location of this package file
 
         """
-        return self.request.app_url("api", "package", package.name, package.filename)
+        fragment = ""
+        if package.data.get("hash_sha256"):
+            fragment = "sha256=" + package.data["hash_sha256"]
+        return self.request.app_url(
+            "api", "package", package.name, package.filename, fragment=fragment
+        )
 
     def download_response(self, package: Package):
         """

--- a/scripts/calculate_hashes_blob_storage.py
+++ b/scripts/calculate_hashes_blob_storage.py
@@ -1,0 +1,30 @@
+import argparse
+from azure.storage.blob import BlobServiceClient
+import hashlib
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("storage_account_url", help="Storage account url")
+parser.add_argument("storage_account_key", help="Storage account key")
+parser.add_argument("container_name", help="Container")
+parser.add_argument("prefix", default="", help="Path prefix")
+args = parser.parse_args()
+
+blob_service_client = BlobServiceClient(
+    account_url=args.storage_account_url, credential=args.storage_account_key
+)
+
+container_client = blob_service_client.get_container_client(args.container_name)
+
+for blob_properties in container_client.list_blobs(name_starts_with=args.prefix):
+    metadata = blob_properties.metadata or {}
+    key = blob_properties.name
+    if "hash_sha256" in metadata and "hash_md5" in metadata:
+        continue
+
+    blob = container_client.get_blob_client(key)
+    data = blob.download_blob().readall()
+    metadata["hash_sha256"] = hashlib.sha256(data).hexdigest()
+    metadata["hash_md5"] = hashlib.md5(data).hexdigest()
+    blob.set_blob_metadata(metadata)
+    print("Updated metadata on {0}".format(key))

--- a/scripts/calculate_hashes_s3.py
+++ b/scripts/calculate_hashes_s3.py
@@ -1,0 +1,30 @@
+import argparse
+import boto3
+import hashlib
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("s3_bucket", help="S3 Bucket name")
+parser.add_argument("s3_prefix", default="", help="S3 path prefix")
+args = parser.parse_args()
+
+s3 = boto3.client("s3")
+
+paginator = s3.get_paginator("list_objects").paginate(
+    Bucket=args.s3_bucket, Prefix=args.s3_prefix
+)
+
+for page in paginator:
+    for obj in page["Contents"]:
+        key = obj["Key"]
+        resp = s3.head_object(Bucket=args.s3_bucket, Key=key)
+        metadata = resp["Metadata"]
+        if "hash_sha256" in metadata and "hash_md5" in metadata:
+            continue
+
+        resp = s3.get_object(Bucket=args.s3_bucket, Key=key)
+        data = resp["Body"].read()
+        metadata["hash_sha256"] = hashlib.sha256(data).hexdigest()
+        metadata["hash_md5"] = hashlib.md5(data).hexdigest()
+        s3.put_object(Bucket=args.s3_bucket, Key=key, Body=data, Metadata=metadata)
+        print("Updated metadata on {0}".format(key))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 """ Tests for API endpoints """
+from io import BytesIO
 from mock import MagicMock, patch
 from pyramid.httpexceptions import HTTPBadRequest, HTTPForbidden
 
@@ -19,14 +20,14 @@ class TestApi(MockServerTest):
     def test_list_packages(self):
         """ List all packages """
         p1 = make_package()
-        self.db.upload(p1.filename, None)
+        self.db.upload(p1.filename, BytesIO(b"test1234"))
         pkgs = api.all_packages(self.request)
         self.assertEqual(pkgs["packages"], [p1.name])
 
     def test_list_packages_no_perm(self):
         """ If no read permission, package not in all_packages """
         p1 = make_package()
-        self.db.upload(p1.filename, None)
+        self.db.upload(p1.filename, BytesIO(b"test1234"))
         self.access.has_permission.return_value = False
         pkgs = api.all_packages(self.request)
         self.assertEqual(pkgs["packages"], [])
@@ -34,7 +35,7 @@ class TestApi(MockServerTest):
     def test_list_packages_verbose(self):
         """ List all package data """
         p1 = make_package()
-        p1 = self.db.upload(p1.filename, None)
+        p1 = self.db.upload(p1.filename, BytesIO(b"test1234"))
         pkgs = api.all_packages(self.request, True)
         self.assertEqual(
             pkgs["packages"],

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -34,10 +34,10 @@ class TestBaseCache(unittest.TestCase):
         cache = DummyCache()
         pkg = cache.upload("a-1.tar.gz", BytesIO(b"test1234"), "a")
         self.assertEqual(
-            pkg["data"]["hash_sha256"],
+            pkg.data["hash_sha256"],
             "937e8d5fbb48bd4949536cd65b8d35c426b80d2f830c5c308e2cdec422ae2244",
         )
-        self.assertEqual(pkg["data"]["hash_md5"], "16d7a4fca7442dda3ad93c9a726597e4")
+        self.assertEqual(pkg.data["hash_md5"], "16d7a4fca7442dda3ad93c9a726597e4")
 
     def test_upload_overwrite(self):
         """ Uploading a preexisting packages overwrites current package """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -29,6 +29,16 @@ class TestBaseCache(unittest.TestCase):
         self.assertEqual(hash(p1), hash(p2))
         self.assertEqual(p1, p2)
 
+    def test_upload_hash_generation(self):
+        """ Uploading a package generates SHA256 and MD5 hashes """
+        cache = DummyCache()
+        pkg = cache.upload("a-1.tar.gz", BytesIO(b"test1234"), "a")
+        self.assertEqual(
+            pkg["data"]["hash_sha256"],
+            "937e8d5fbb48bd4949536cd65b8d35c426b80d2f830c5c308e2cdec422ae2244",
+        )
+        self.assertEqual(pkg["data"]["hash_md5"], "16d7a4fca7442dda3ad93c9a726597e4")
+
     def test_upload_overwrite(self):
         """ Uploading a preexisting packages overwrites current package """
         cache = DummyCache()
@@ -241,7 +251,14 @@ class TestSQLiteCache(unittest.TestCase):
         """ reload_from_storage() inserts packages into the database """
         keys = [
             make_package(factory=SQLPackage),
-            make_package("mypkg2", "1.3.4", "my/other/path", factory=SQLPackage),
+            make_package(
+                "mypkg2",
+                "1.3.4",
+                "my/other/path",
+                factory=SQLPackage,
+                hash_md5="md5",
+                hash_sha256="sha256",
+            ),
         ]
         self.storage.list.return_value = keys
         self.db.reload_from_storage()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -610,19 +610,23 @@ class TestRedisCache(unittest.TestCase):
         with patch.object(self.db, "allow_overwrite", False):
             name, version = "a", "1"
             path1 = "old_package_path-1.tar.gz"
-            self.db.upload(path1, None, name, version)
+            self.db.upload(path1, BytesIO(b"test1234"), name, version)
             path2 = "new_path-1.whl"
-            self.db.upload(path2, None, name, version)
+            self.db.upload(path2, BytesIO(b"test1234"), name, version)
 
             all_versions = self.db.all(name)
             self.assertEqual(len(all_versions), 2)
 
     def test_summary(self):
         """ summary constructs per-package metadata summary """
-        self.db.upload("pkg1-0.3a2.tar.gz", None, "pkg1", "0.3a2")
-        self.db.upload("pkg1-1.1.tar.gz", None, "pkg1", "1.1")
-        p1 = self.db.upload("pkg1a2.tar.gz", None, "pkg1", "1.1.1a2", "summary")
-        p2 = self.db.upload("pkg2.tar.gz", None, "pkg2", "0.1dev2", "summary")
+        self.db.upload("pkg1-0.3a2.tar.gz", BytesIO(b"test1234"), "pkg1", "0.3a2")
+        self.db.upload("pkg1-1.1.tar.gz", BytesIO(b"test1234"), "pkg1", "1.1")
+        p1 = self.db.upload(
+            "pkg1a2.tar.gz", BytesIO(b"test1234"), "pkg1", "1.1.1a2", "summary"
+        )
+        p2 = self.db.upload(
+            "pkg2.tar.gz", BytesIO(b"test1234"), "pkg2", "0.1dev2", "summary"
+        )
         summaries = self.db.summary()
         self.assertItemsEqual(
             summaries,
@@ -719,12 +723,12 @@ class TestDynamoCache(unittest.TestCase):
     def test_upload(self):
         """ upload() saves package and uploads to storage """
         pkg = make_package(factory=DynamoPackage)
-        self.db.upload(pkg.filename, None, pkg.name, pkg.version)
+        self.db.upload(pkg.filename, BytesIO(b"test1234"), pkg.name, pkg.version)
         count = self.engine.scan(DynamoPackage).count()
         self.assertEqual(count, 1)
         saved_pkg = self.engine.scan(DynamoPackage).first()
         self.assertEqual(saved_pkg, pkg)
-        self.storage.upload.assert_called_with(pkg, None)
+        self.storage.upload.assert_called_with(pkg, ANY)
 
     def test_save(self):
         """ save() puts object into database """
@@ -841,10 +845,14 @@ class TestDynamoCache(unittest.TestCase):
 
     def test_summary(self):
         """ summary constructs per-package metadata summary """
-        self.db.upload("pkg1-0.3a2.tar.gz", None, "pkg1", "0.3a2")
-        self.db.upload("pkg1-1.1.tar.gz", None, "pkg1", "1.1")
-        p1 = self.db.upload("pkg1a2.tar.gz", None, "pkg1", "1.1.1a2", "summary")
-        p2 = self.db.upload("pkg2.tar.gz", None, "pkg2", "0.1dev2", "summary")
+        self.db.upload("pkg1-0.3a2.tar.gz", BytesIO(b"test1234"), "pkg1", "0.3a2")
+        self.db.upload("pkg1-1.1.tar.gz", BytesIO(b"test1234"), "pkg1", "1.1")
+        p1 = self.db.upload(
+            "pkg1a2.tar.gz", BytesIO(b"test1234"), "pkg1", "1.1.1a2", "summary"
+        )
+        p2 = self.db.upload(
+            "pkg2.tar.gz", BytesIO(b"test1234"), "pkg2", "0.1dev2", "summary"
+        )
         summaries = self.db.summary()
         self.assertItemsEqual(
             summaries,
@@ -867,9 +875,9 @@ class TestDynamoCache(unittest.TestCase):
         with patch.object(self.db, "allow_overwrite", False):
             name, version = "a", "1"
             path1 = "old_package_path-1.tar.gz"
-            self.db.upload(path1, None, name, version)
+            self.db.upload(path1, BytesIO(b"test1234"), name, version)
             path2 = "new_path-1.whl"
-            self.db.upload(path2, None, name, version)
+            self.db.upload(path2, BytesIO(b"test1234"), name, version)
 
             all_versions = self.db.all(name)
             self.assertEqual(len(all_versions), 2)
@@ -900,12 +908,14 @@ class TestDynamoCache(unittest.TestCase):
     def test_upload_no_summary(self):
         """ upload() saves package even when there is no summary """
         pkg = make_package(factory=DynamoPackage)
-        self.db.upload(pkg.filename, None, pkg.name, pkg.version, summary="")
+        self.db.upload(
+            pkg.filename, BytesIO(b"test1234"), pkg.name, pkg.version, summary=""
+        )
         count = self.engine.scan(DynamoPackage).count()
         self.assertEqual(count, 1)
         saved_pkg = self.engine.scan(DynamoPackage).first()
         self.assertEqual(saved_pkg, pkg)
-        self.storage.upload.assert_called_with(pkg, None)
+        self.storage.upload.assert_called_with(pkg, ANY)
 
     def test_check_health_success(self):
         """ check_health returns True for good connection """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """ Tests for database cache implementations """
+from io import BytesIO
 import calendar
 import transaction
 import unittest
@@ -32,14 +33,14 @@ class TestBaseCache(unittest.TestCase):
         """ Uploading a preexisting packages overwrites current package """
         cache = DummyCache()
         cache.allow_overwrite = True
-        name, filename = "a", "a-1.tar.gz"
-        cache.upload(filename, "old", name)
-        cache.upload(filename, "new", name)
+        name, filename, content = "a", "a-1.tar.gz", BytesIO(b"new")
+        cache.upload(filename, BytesIO(b"old"), name)
+        cache.upload(filename, content, name)
 
         all_versions = cache.all(name)
         self.assertEqual(len(all_versions), 1)
-        data = cache.storage.open(all_versions[0])
-        self.assertEqual(data, "new")
+        data = cache.storage.open(all_versions[0]).read()
+        self.assertEqual(data, b"new")
 
         stored_pkgs = list(cache.storage.list(cache.new_package))
         self.assertEqual(len(stored_pkgs), 1)
@@ -49,9 +50,9 @@ class TestBaseCache(unittest.TestCase):
         cache = DummyCache()
         cache.allow_overwrite = False
         name, version, filename = "a", "1", "a-1.tar.gz"
-        cache.upload(filename, None, name, version)
+        cache.upload(filename, BytesIO(b"test1234"), name, version)
         with self.assertRaises(ValueError):
-            cache.upload(filename, None, name, version)
+            cache.upload(filename, BytesIO(b"test1234"), name, version)
 
     def test_multiple_packages_same_version(self):
         """ Can upload multiple packages that have the same version """
@@ -59,9 +60,9 @@ class TestBaseCache(unittest.TestCase):
         cache.allow_overwrite = False
         name, version = "a", "1"
         path1 = "old_package_path-1.tar.gz"
-        cache.upload(path1, None, name, version)
+        cache.upload(path1, BytesIO(b"test1234"), name, version)
         path2 = "new_path-1.whl"
-        cache.upload(path2, None, name, version)
+        cache.upload(path2, BytesIO(b"test1234"), name, version)
 
         all_versions = cache.all(name)
         self.assertEqual(len(all_versions), 2)
@@ -77,10 +78,14 @@ class TestBaseCache(unittest.TestCase):
     def test_summary(self):
         """ summary constructs per-package metadata summary """
         cache = DummyCache()
-        cache.upload("pkg1-0.3.tar.gz", None)
-        cache.upload("pkg1-1.1.tar.gz", None)
-        p1 = cache.upload("pkg1a2.tar.gz", None, "pkg1", "1.1.1a2", "summary")
-        p2 = cache.upload("pkg2.tar.gz", None, "pkg2", "0.1dev2", "summary")
+        cache.upload("pkg1-0.3.tar.gz", BytesIO(b"test1234"))
+        cache.upload("pkg1-1.1.tar.gz", BytesIO(b"test1234"))
+        p1 = cache.upload(
+            "pkg1a2.tar.gz", BytesIO(b"test1234"), "pkg1", "1.1.1a2", "summary"
+        )
+        p2 = cache.upload(
+            "pkg2.tar.gz", BytesIO(b"test1234"), "pkg2", "0.1dev2", "summary"
+        )
         summaries = cache.summary()
         self.assertItemsEqual(
             summaries,
@@ -173,19 +178,22 @@ class TestSQLiteCache(unittest.TestCase):
     def test_upload(self):
         """ upload() saves package and uploads to storage """
         pkg = make_package(factory=SQLPackage)
-        self.db.upload(pkg.filename, None, pkg.name, pkg.version)
+        content = BytesIO(b"test1234")
+        self.db.upload(pkg.filename, content, pkg.name, pkg.version)
         count = self.sql.query(SQLPackage).count()
         self.assertEqual(count, 1)
         saved_pkg = self.sql.query(SQLPackage).first()
         self.assertEqual(saved_pkg, pkg)
-        self.storage.upload.assert_called_with(pkg, None)
+        # If calculate hashes is on, it'll read the data
+        # and rewrap with BytesIO
+        self.storage.upload.assert_called_with(pkg, ANY)
 
     def test_upload_overwrite(self):
         """ Uploading a preexisting packages overwrites current package """
         self.db.allow_overwrite = True
         name, filename = "a", "a-1.tar.gz"
-        self.db.upload(filename, "old", name)
-        self.db.upload(filename, "new", name)
+        self.db.upload(filename, BytesIO(b"old"), name)
+        self.db.upload(filename, BytesIO(b"new"), name)
 
         all_versions = self.db.all(name)
         self.assertEqual(len(all_versions), 1)
@@ -314,10 +322,10 @@ class TestSQLiteCache(unittest.TestCase):
 
     def test_summary(self):
         """ summary constructs per-package metadata summary """
-        self.db.upload("pkg1-0.3.tar.gz", None, "pkg1", "0.3")
-        self.db.upload("pkg1-1.1.tar.gz", None, "pkg1", "1.1")
-        p1 = self.db.upload("pkg1a2.tar.gz", None, "pkg1", "1.1.1a2")
-        p2 = self.db.upload("pkg2.tar.gz", None, "pkg2", "0.1dev2")
+        self.db.upload("pkg1-0.3.tar.gz", BytesIO(b"test1234"), "pkg1", "0.3")
+        self.db.upload("pkg1-1.1.tar.gz", BytesIO(b"test1234"), "pkg1", "1.1")
+        p1 = self.db.upload("pkg1a2.tar.gz", BytesIO(b"test1234"), "pkg1", "1.1.1a2")
+        p2 = self.db.upload("pkg2.tar.gz", BytesIO(b"test1234"), "pkg2", "0.1dev2")
         s1, s2 = self.db.summary()  # pylint: disable=E0632
         # Order them correctly. assertItemsEqual isn't playing nice in py2.6
         if s1["name"] == "pkg2":
@@ -340,9 +348,9 @@ class TestSQLiteCache(unittest.TestCase):
         with patch.object(self.db, "allow_overwrite", False):
             name, version = "a", "1"
             path1 = "old_package_path-1.tar.gz"
-            self.db.upload(path1, None, name, version)
+            self.db.upload(path1, BytesIO(b"test1234"), name, version)
             path2 = "new_path-1.whl"
-            self.db.upload(path2, None, name, version)
+            self.db.upload(path2, BytesIO(b"test1234"), name, version)
 
             all_versions = self.db.all(name)
             self.assertEqual(len(all_versions), 2)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -42,9 +42,33 @@ class TestPackages(MockServerTest):
         self.request.db.all.side_effect = get_packages
         result = list_packages(self.request)
         expected = {
-            "b0": {"requires_python": None, "url": "b0.ext"},
-            "c0": {"requires_python": None, "url": "c0.ext"},
-            "c1": {"requires_python": None, "url": "c1.ext"},
-            "c2": {"requires_python": None, "url": "c2.ext"},
+            "b0": {
+                "requires_python": None,
+                "hash_sha256": None,
+                "hash_md5": None,
+                "non_hashed_url": "b0.ext",
+                "url": "b0.ext",
+            },
+            "c0": {
+                "requires_python": None,
+                "hash_sha256": None,
+                "hash_md5": None,
+                "non_hashed_url": "c0.ext",
+                "url": "c0.ext",
+            },
+            "c1": {
+                "requires_python": None,
+                "hash_sha256": None,
+                "hash_md5": None,
+                "non_hashed_url": "c1.ext",
+                "url": "c1.ext",
+            },
+            "c2": {
+                "requires_python": None,
+                "hash_sha256": None,
+                "hash_md5": None,
+                "non_hashed_url": "c2.ext",
+                "url": "c2.ext",
+            },
         }
         self.assertEqual(result, {"pkgs": expected})

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,4 +1,5 @@
 """ Tests for view security and auth """
+from io import BytesIO
 import base64
 import webtest
 from collections import defaultdict
@@ -75,7 +76,10 @@ class TestEndpointSecurity(unittest.TestCase):
     def setUp(self):
         cache = GlobalDummyCache()
         cache.upload(
-            self.package.filename, None, self.package.name, self.package.version
+            self.package.filename,
+            BytesIO(b"test1234"),
+            self.package.name,
+            self.package.version,
         )
 
     def tearDown(self):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,4 +1,6 @@
 """ Unit tests for the simple endpoints """
+from io import BytesIO
+
 from mock import MagicMock, patch
 from types import MethodType
 
@@ -15,6 +17,12 @@ from pypicloud.views.simple import (
 import unittest
 
 
+class FileUpload(object):
+    def __init__(self, name, data):
+        self.filename = name
+        self.file = BytesIO(data)
+
+
 class TestSimple(MockServerTest):
 
     """ Unit tests for the /simple endpoints """
@@ -26,7 +34,7 @@ class TestSimple(MockServerTest):
     def test_upload(self):
         """ Upload endpoint returns the result of api call """
         self.params = {":action": "file_upload"}
-        name, version, content = "foo", "bar", MagicMock()
+        name, version, content = "foo", "bar", FileUpload("testfile", b"test1234")
         content.filename = "foo-1.2.tar.gz"
         pkg = upload(self.request, content, name, version)
 
@@ -42,7 +50,7 @@ class TestSimple(MockServerTest):
     def test_upload_no_write_permission(self):
         """ Upload without write permission returns 403 """
         self.params = {":action": "file_upload"}
-        name, version, content = "foo", "bar", MagicMock()
+        name, version, content = "foo", "bar", FileUpload("testfile", b"test1234")
         content.filename = "foo-1.2.tar.gz"
         self.request.access.has_permission.return_value = False
         response = upload(self.request, content, name, version)
@@ -51,18 +59,18 @@ class TestSimple(MockServerTest):
     def test_upload_duplicate(self):
         """ Uploading a duplicate package returns 409 """
         self.params = {":action": "file_upload"}
-        name, version, content = "foo", "1.2", MagicMock()
+        name, version, content = "foo", "1.2", FileUpload("testfile", b"test1234")
         content.filename = "foo-1.2.tar.gz"
-        self.db.upload(content.filename, content, name)
+        self.db.upload(content.filename, content.file, name)
         response = upload(self.request, content, name, version)
         self.assertEqual(response.status_code, 409)
 
     def test_search(self):
         """ Pip search executes successfully """
         self.params = {":action": "file_upload"}
-        name1, version1, content1 = "foo", "1.1", MagicMock()
+        name1, version1, content1 = "foo", "1.1", FileUpload("testfile", b"test1234")
         content1.filename = "bar-1.2.tar.gz"
-        name2, version2, content2 = "bar", "1.0", MagicMock()
+        name2, version2, content2 = "bar", "1.0", FileUpload("testfile", b"test1234")
         content2.filename = "bar-1.2.tar.gz"
         upload(self.request, content1, name1, version1)
         upload(self.request, content2, name2, version2)
@@ -75,11 +83,11 @@ class TestSimple(MockServerTest):
     def test_search_permission_filter(self):
         """ Pip search only gets results that user has read perms for """
         self.params = {":action": "file_upload"}
-        name1, version1, content1 = "pkg1", "1.1", MagicMock()
+        name1, version1, content1 = "pkg1", "1.1", FileUpload("testfile", b"test1234")
         content1.filename = "pkg1-1.1.tar.gz"
-        name2, version2, content2 = "pkg2", "1.0", MagicMock()
+        name2, version2, content2 = "pkg2", "1.0", FileUpload("testfile", b"test1234")
         content2.filename = "pkg2-1.0.tar.gz"
-        name3, version3, content3 = "other", "1.0", MagicMock()
+        name3, version3, content3 = "other", "1.0", FileUpload("testfile", b"test1234")
         content3.filename = "other-1.0.tar.gz"
         upload(self.request, content1, name1, version1)
         upload(self.request, content2, name2, version2)
@@ -265,6 +273,9 @@ class PackageReadTestBase(unittest.TestCase):
                     self.package.filename: {
                         "url": self.package.get_url(request),
                         "requires_python": None,
+                        "hash_sha256": None,
+                        "hash_md5": None,
+                        "non_hashed_url": self.package.get_url(request),
                     }
                 }
             },
@@ -300,6 +311,9 @@ class PackageReadTestBase(unittest.TestCase):
                     self.package.filename: {
                         "url": self.package.get_url(request),
                         "requires_python": None,
+                        "non_hashed_url": self.package.get_url(request),
+                        "hash_sha256": None,
+                        "hash_md5": None,
                     },
                     f2name: self.fallback_packages[f2name],
                 }
@@ -546,6 +560,9 @@ class TestCacheAlwaysShow(PackageReadTestBase):
                     self.package.filename: {
                         "url": self.package.get_url(req),
                         "requires_python": None,
+                        "non_hashed_url": self.package.get_url(req),
+                        "hash_sha256": None,
+                        "hash_md5": None,
                     },
                     self.package2.filename: self.fallback_packages[p2.filename],
                 }
@@ -565,6 +582,9 @@ class TestCacheAlwaysShow(PackageReadTestBase):
                     self.package.filename: {
                         "url": self.package.get_url(req),
                         "requires_python": None,
+                        "non_hashed_url": self.package.get_url(req),
+                        "hash_sha256": None,
+                        "hash_md5": None,
                     },
                     self.package2.filename: self.fallback_packages[p2.filename],
                 }

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ extras =
 ignore_errors = true
 commands =
     {envpython} setup.py check --restructuredtext -s
-    black --check pypicloud tests setup.py
+    black --check pypicloud tests setup.py scripts
     mypy pypicloud
     pylint --rcfile=.pylintrc pypicloud tests
 


### PR DESCRIPTION
Adds logic to calculate package hashes on upload, adds it to file metadata as well so if the database is rebuilt, re-hashing is not needed.

New option `pypi.calculate_package_hashes` added to control whether to calculate package hashes. Enabled by default as that means the JSON and simple API will act more like the real PyPI.

Depends on #243 
Fixes #222

## TODO:
* [x] add hashing logic
* [x] ~test for sha256 url fragment in simple endpoint~
* [x] test for hashes in json output
* [x] test for hash calculation on upload
* [x] test for hash retrieval on list
* [x] update docs about `pypi.calculate_package_hashes` option
* [x] Create Azure and S3 migration script (havent used GCE so someone else can create that when needed)