### PR TITLE
Add flag to pypicloud-gen-password for reading password from stdin

### DIFF
--- a/pypicloud/scripts.py
+++ b/pypicloud/scripts.py
@@ -21,6 +21,8 @@ def gen_password(argv=None):
     if argv is None:
         argv = sys.argv[1:]
     parser = argparse.ArgumentParser(gen_password.__doc__)
+    parser.add_argument("-i", help="Read password from stdin",
+        action="store_true")
     parser.add_argument("-r", help="Number of rounds", type=int)
     parser.add_argument(
         "-s",
@@ -29,19 +31,27 @@ def gen_password(argv=None):
         choices=SCHEMES,
     )
     args = parser.parse_args(argv)
-    print(_gen_password(args.s, args.r))
+    if args.i:
+        password = sys.stdin.readline()
+    else:
+        password = _get_password()
+    print(_gen_password(password, args.s, args.r))
 
 
-def _gen_password(scheme=None, rounds=None):
+def _get_password():
     """ Prompt user for a password twice for safety """
-    pwd_context = get_pwd_context(scheme, rounds)
     while True:
         password = getpass.getpass()
         verify = getpass.getpass()
         if password == verify:
-            return pwd_context.hash(password)
+            return password
         else:
             print("Passwords do not match!")
+
+
+def _gen_password(password, scheme=None, rounds=None):
+    pwd_context = get_pwd_context(scheme, rounds)
+    return pwd_context.hash(password)
 
 
 NO_DEFAULT = object()


### PR DESCRIPTION
This feature would be used for scripting the password hash creation. The specific use case I have in mind is to generate the hashed password from a Kubernetes secret using an init container before starting pypicloud. 

The equivalent functionality is also available with the `mkpasswd` command which is part of the `whois` package, (`mkpasswd -m sha-512 -s -R 20500`) but it makes sense for the `pypicloud-gen-password` utility to support it as well.