### PR TITLE
Fixed content type typo

### DIFF
--- a/pypicloud/views/api.py
+++ b/pypicloud/views/api.py
@@ -128,7 +128,7 @@ def download_package(context, request):
             public=True, max_age=request.registry.package_max_age
         )
         request.response.headers.update(cache)
-        request.response.content_type = "application/octect-stream"
+        request.response.content_type = "application/octet-stream"
         return request.response
     response = request.db.download_response(package)
     return response


### PR DESCRIPTION
This pull request fixed a typo in response content type. It seems have been introduced with `stream_files` support.