### PR TITLE
tolerate 5xx errors from json locator

### DIFF
--- a/pypicloud/locator.py
+++ b/pypicloud/locator.py
@@ -22,7 +22,7 @@ class SimpleJsonLocator(object):
         url = "%s/pypi/%s/json" % (self.base_index, project_name)
         response = requests.get(url)
         # Return empty list for 4xx
-        if 400 <= response.status_code < 500:
+        if 400 <= response.status_code < 600:
             return []
         response.raise_for_status()
         data = response.json()


### PR DESCRIPTION
During the pypi.org outage last month we noticed our local pypicloud cache was also down even though we've configured it to tolerate cache packages and tolerate outages:

```
pypi.fallback = cache
pypi.cache_update = everyone
pypi.always_show_upstream = true
pypi.use_json_scraper = true
```

Recreated the error locally by pointing `pypi.fallback_base_url = http://127.0.0.1:9000` to a local service that serves 503 responses like pypi.org did during the outage. 
Found that by expanding the error codes tolerated, we could survive the next pypi.org outage.

Let me know what you think.