### PR TITLE
Fixing an issue with graceful reload

### DIFF
--- a/pypicloud/models.py
+++ b/pypicloud/models.py
@@ -90,13 +90,17 @@ class Package(object):
         return metadata
 
     def __hash__(self):
-        return hash(self.name) + hash(self.version)
+        return hash(self.filename)
 
     def __eq__(self, other):
-        return self.name == other.name and self.version == other.version
+        return isinstance(other, Package) and self.filename == other.filename
 
     def __lt__(self, other):
-        return (self.name, self.parsed_version) < (other.name, other.parsed_version)
+        return (self.name, self.parsed_version, self.filename) < (
+            other.name,
+            other.parsed_version,
+            self.filename,
+        )
 
     def __repr__(self):
         return self.__str__()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -25,11 +25,18 @@ class TestBaseCache(unittest.TestCase):
     """ Tests for the caching base class """
 
     def test_equality(self):
-        """ Two packages with same name & version should be equal """
-        p1 = make_package(filename="wibbly")
-        p2 = make_package(filename="wobbly")
+        """ Two packages with same filename should be equal """
+        p1 = make_package(filename="foo")
+        p2 = make_package(filename="foo")
         self.assertEqual(hash(p1), hash(p2))
         self.assertEqual(p1, p2)
+
+    def test_not_equal(self):
+        """ Two packages with different filenames should not be equal """
+        p1 = make_package(filename="foobar")
+        p2 = make_package(filename="foo")
+        self.assertNotEqual(hash(p1), hash(p2))
+        self.assertNotEqual(p1, p2)
 
     def test_upload_hash_generation(self):
         """ Uploading a package generates SHA256 and MD5 hashes """


### PR DESCRIPTION
The reload logic was treating packages as the same if their names and
versions matched. This breaks down if a package has multiple builds for
the same name + version (e.g. wheel, tar.gz, windows, mac, linux, etc).
The solution is to compare the filenames to judge equality instead of
comparing name + version.