### PR TITLE
Update summary field for SQLPackage model to accommodate large summaries

### DIFF
--- a/pypicloud/cache/sql.py
+++ b/pypicloud/cache/sql.py
@@ -95,7 +95,8 @@ class SQLPackage(Package, Base):
     name = Column(String(255, convert_unicode=True), index=True, nullable=False)
     version = Column(String(1000, convert_unicode=True), nullable=False)
     last_modified = Column(TZAwareDateTime(), index=True, nullable=False)
-    summary = Column(String(255, convert_unicode=True), index=True, nullable=True)
+    # TEXT, as pypi does the same, and using String(N) would mismatch with pypi
+    summary = Column(TEXT, index=True, nullable=True)
     data = Column(JSONEncodedDict(), nullable=False)
 
 


### PR DESCRIPTION
Fixes #275 

 - Using `Text` field as pypi org has the same limit on summary field for packages. [reference](https://github.com/pypa/warehouse/blob/main/warehouse/packaging/models.py#L367)