### PR TITLE
Fix formatting in configuration docs

### DIFF
--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -103,6 +103,7 @@ the list of groups that are allowed to trigger the operation that fetches
 packages from ``fallback_base_url``.  (default ['authenticated'])
 
 ``pypi.calculate_package_hashes``
+~~~~~~~~~~~~~~~~~~~~~
 **Argument:** bool, optional
 
 Package SHA256 and MD5 hashes are now calculated by default when a package is

--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -103,7 +103,7 @@ the list of groups that are allowed to trigger the operation that fetches
 packages from ``fallback_base_url``.  (default ['authenticated'])
 
 ``pypi.calculate_package_hashes``
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Argument:** bool, optional
 
 Package SHA256 and MD5 hashes are now calculated by default when a package is


### PR DESCRIPTION
option `pypi.calculate_package_hashes` was formatted incorrectly