### PR TITLE
Added tracking of package uploader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ _local.db
 .idea
 .mypy_cache
 .direnv/
+.tox
+.local
+.pylint.d

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -98,6 +98,7 @@ class ICache(object):
         name: Optional[str] = None,
         version: Optional[str] = None,
         summary: Optional[str] = None,
+        uploader: Optional[str] = None,
         requires_python: Optional[str] = None,
     ) -> Package:
         """
@@ -117,6 +118,8 @@ class ICache(object):
             from filename)
         summary : str, optional
             The summary of the package
+        uploader : str, optional
+            The uploader of the package
         requires_python : str, optional
             The Python version requirement
 
@@ -145,7 +148,9 @@ class ICache(object):
             metadata["hash_md5"] = hashlib.md5(file_data).hexdigest()
             data = BytesIO(file_data)
 
-        new_pkg = self.new_package(name, version, filename, summary=summary, **metadata)
+        new_pkg = self.new_package(
+            name, version, filename, summary=summary, uploader=uploader, **metadata
+        )
         self.storage.upload(new_pkg, data)
         self.save(new_pkg)
         return new_pkg

--- a/pypicloud/cache/dynamo.py
+++ b/pypicloud/cache/dynamo.py
@@ -35,6 +35,7 @@ class DynamoPackage(Package, Model):
     version = Field()
     last_modified = Field(data_type=datetime)
     summary = Field()
+    uploader = Field()
     data = Field(data_type=dict)
 
     def __init__(self, *args, **kwargs):

--- a/pypicloud/cache/redis_cache.py
+++ b/pypicloud/cache/redis_cache.py
@@ -80,11 +80,12 @@ class RedisCache(ICache):
         filename = data.pop("filename")
         last_modified = utcfromtimestamp(float(data.pop("last_modified")))
         summary = data.pop("summary")
+        uploader = data.pop("uploader")
         if summary == "":
             summary = None
         kwargs = dict(((k, json.loads(v)) for k, v in data.items()))
         return self.new_package(
-            name, version, filename, last_modified, summary, **kwargs
+            name, version, filename, last_modified, summary, uploader, **kwargs
         )
 
     def all(self, name):
@@ -160,6 +161,7 @@ class RedisCache(ICache):
             "filename": package.filename,
             "last_modified": last_modified,
             "summary": package.summary or "",
+            "uploader": package.uploader,
         }
         for key, value in package.data.items():
             data[key] = json.dumps(value)

--- a/pypicloud/cache/sql.py
+++ b/pypicloud/cache/sql.py
@@ -109,6 +109,7 @@ class SQLPackage(Package, Base):
     last_modified = Column(TZAwareDateTime(), index=True, nullable=False)
     # TEXT, as pypi does the same, and using String(N) would mismatch with pypi
     summary = Column(Text(), nullable=True)
+    package = Column(Text(), nullable=True)
     data = Column(JSONEncodedDict(), nullable=False)
 
 

--- a/pypicloud/static/partial/package.html
+++ b/pypicloud/static/partial/package.html
@@ -43,6 +43,7 @@
             <th>Package</th>
             <th>Version</th>
             <th>Uploaded</th>
+            <th>Uploader</th>
           </tr>
         </thead>
         <tbody>
@@ -60,6 +61,9 @@
                 <i class="fa fa-refresh fa-spin" ng-show="package.deleting"></i>
                 Delete
               </button>
+            </td>
+            <td>
+              {{ package.uploader !== "" ? package.uploader : "&lt;unknown&gt;" }}
             </td>
           </tr>
         </tbody>

--- a/pypicloud/views/api.py
+++ b/pypicloud/views/api.py
@@ -153,6 +153,7 @@ def upload_package(context, request, content, summary=None, requires_python=None
             name=context.name,
             summary=summary,
             requires_python=requires_python,
+            uploader=request.authenticated_userid,
         )
     except ValueError as e:  # pragma: no cover
         return HTTPBadRequest(*e.args)

--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -42,6 +42,7 @@ def upload(
                 name=name,
                 version=version,
                 summary=summary,
+                uploader=request.authenticated_userid,
                 requires_python=requires_python or None,
             )
         except ValueError as e:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,13 +21,14 @@ def make_package(
     filename=None,
     last_modified=None,
     summary="summary",
+    uploader="test_uploader",
     factory=Package,
     **kwargs
 ):
     """Convenience method for constructing a package"""
     filename = filename or "%s-%s.tar.gz" % (name, version)
     return factory(
-        name, version, filename, last_modified or utcnow(), summary, **kwargs
+        name, version, filename, last_modified or utcnow(), summary, uploader, **kwargs
     )
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -283,6 +283,7 @@ class TestSQLiteCache(unittest.TestCase):
                 "1.3.4",
                 "my/other/path",
                 factory=SQLPackage,
+                uploader="test",
                 hash_md5="md5",
                 hash_sha256="sha256",
             ),
@@ -496,6 +497,7 @@ class TestRedisCache(unittest.TestCase):
             "filename": pkg.filename,
             "last_modified": lm_str,
             "summary": pkg.summary,
+            "uploader": pkg.uploader,
         }
         pkg_data.update(pkg.data)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -137,6 +137,6 @@ class TestEndpointSecurity(unittest.TestCase):
     def test_api_rebuild_admin(self):
         """/api/rebuild requires admin"""
         response = self.app.get(
-            "/api/rebuild/", expect_errors=True, headers=_auth("user2", "user2")
+            "/admin/rebuild/", expect_errors=True, headers=_auth("user2", "user2")
         )
-        self.assertEqual(response.status_int, 404)
+        self.assertEqual(response.status_int, 403)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -140,3 +140,12 @@ class TestEndpointSecurity(unittest.TestCase):
             "/admin/rebuild/", expect_errors=True, headers=_auth("user2", "user2")
         )
         self.assertEqual(response.status_int, 403)
+
+    def test_api_unknown_url(self):
+        """unknown url returns 404"""
+        response = self.app.get(
+            "/api/non_existant_url/",
+            expect_errors=True,
+            headers=_auth("user2", "user2"),
+        )
+        self.assertEqual(response.status_int, 404)

--- a/tests/vcr_cassettes/test_list.yaml
+++ b/tests/vcr_cassettes/test_list.yaml
@@ -28,6 +28,8 @@ interactions:
       - test
       x-ms-meta-version:
       - '1.2'
+      x-ms-meta-uploader:
+      - 'azure_user'
       x-ms-version:
       - '2019-07-07'
     method: PUT
@@ -167,6 +169,8 @@ interactions:
       - test
       x-ms-meta-version:
       - '1.2'
+      x-ms-meta-uploader:
+      - 'azure_user'
       x-ms-request-id:
       - db2c5cca-601e-004a-1ee1-27b949000000
       x-ms-server-encrypted:


### PR DESCRIPTION
Added feature of tracking the user who uploaded a package in the database and in the cache.
The user is displayed as an additional column in the package page in the UI.