### PR TITLE
Allowing admin users to delete even when `pypi.allow_delete` is False.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ _local.db
 .idea
 .mypy_cache
 .direnv/
+.local

--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -114,19 +114,15 @@ https://github.com/stevearc/pypicloud/tree/master/scripts
 
 ``pypi.allow_overwrite``
 ~~~~~~~~~~~~~~~~~~~~~~~~
-**Argument:** {'never', 'write', 'admin'}, optional
+**Argument:** list, optional
 
-Allow users to upload packages that will overwrite an existing version (default 'never')
-If configured as 'write', users with write permission to the package will be able to override it.
-If configured as 'admin', only admin users will be able to override it.
+List of groups that are allowed to overwrite existing packages. Defaults to no groups
 
 ``pypi.allow_delete``
 ~~~~~~~~~~~~~~~~~~~~~~~~
-**Argument:** {'never', 'write', 'admin'}, optional
+**Argument:** list, optional
 
-Allow users to delete packages (default 'write')
-If configured as 'write', users with write permission to the package will be able to override it.
-If configured as 'admin', only admin users will be able to override it.
+List of groups that are allowed to delete existing packages. Defaults to authenticated
 
 ``pypi.realm``
 ~~~~~~~~~~~~~~

--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -114,11 +114,26 @@ https://github.com/stevearc/pypicloud/tree/master/scripts
 
 ``pypi.allow_overwrite``
 ~~~~~~~~~~~~~~~~~~~~~~~~
+**DEPRECATED** see ``pypi.allow_overwrite_groups``
+**Argument:** bool, optional
+
+
+Allow users to upload packages that will overwrite an existing version (default False)
+
+``pypi.allow_overwrite_groups``
+~~~~~~~~~~~~~~~~~~~~~~~~
 **Argument:** list, optional
 
 List of groups that are allowed to overwrite existing packages. Defaults to no groups
 
 ``pypi.allow_delete``
+~~~~~~~~~~~~~~~~~~~~~~~~
+**DEPRECATED** see ``pypi.allow_delete_groups``
+**Argument:** bool, optional
+
+Allow users to delete packages (default True)
+
+``pypi.allow_delete_groups``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 **Argument:** list, optional
 

--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -114,16 +114,19 @@ https://github.com/stevearc/pypicloud/tree/master/scripts
 
 ``pypi.allow_overwrite``
 ~~~~~~~~~~~~~~~~~~~~~~~~
-**Argument:** bool, optional
+**Argument:** {'never', 'write', 'admin'}, optional
 
-Allow users to upload packages that will overwrite an existing version (default
-False)
+Allow users to upload packages that will overwrite an existing version (default 'never')
+If configured as 'write', users with write permission to the package will be able to override it.
+If configured as 'admin', only admin users will be able to override it.
 
 ``pypi.allow_delete``
 ~~~~~~~~~~~~~~~~~~~~~~~~
-**Argument:** bool, optional
+**Argument:** {'never', 'write', 'admin'}, optional
 
-Allow users to delete packages (default True)
+Allow users to delete packages (default 'write')
+If configured as 'write', users with write permission to the package will be able to override it.
+If configured as 'admin', only admin users will be able to override it.
 
 ``pypi.realm``
 ~~~~~~~~~~~~~~

--- a/pypicloud/__init__.py
+++ b/pypicloud/__init__.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 from urllib.parse import urlencode
 
-import distlib.locators
 from pyramid.config import Configurator
 from pyramid.renderers import JSON, render
 from pyramid.settings import asbool

--- a/pypicloud/access/base.py
+++ b/pypicloud/access/base.py
@@ -102,6 +102,8 @@ class IAccessBackend(object):
         default_write=None,
         disallow_fallback=(),
         cache_update=None,
+        allow_overwrite=None,
+        allow_delete=None,
         pwd_context=None,
         token_expiration=ONE_WEEK,
         signing_key=None,
@@ -111,6 +113,8 @@ class IAccessBackend(object):
         self.default_write = default_write
         self.disallow_fallback = disallow_fallback
         self.cache_update = cache_update
+        self.allow_overwrite = allow_overwrite
+        self.allow_delete = allow_delete
         self.pwd_context = pwd_context
         self.token_expiration = token_expiration
         self.signing_key = signing_key
@@ -128,6 +132,10 @@ class IAccessBackend(object):
             "disallow_fallback": aslist(settings.get("pypi.disallow_fallback", [])),
             "cache_update": aslist(
                 settings.get("pypi.cache_update", ["authenticated"])
+            ),
+            "allow_overwrite": aslist(settings.get("pypi.allow_overwrite", [])),
+            "allow_delete": aslist(
+                settings.get("pypi.allow_delete", ["authenticated"])
             ),
             "pwd_context": get_pwd_context(scheme, rounds),
             "token_expiration": int(settings.get("auth.token_expire", ONE_WEEK)),
@@ -267,6 +275,20 @@ class IAccessBackend(object):
         Return True if the user has permissions to update the pypi cache
         """
         return self.in_any_group(self.request.authenticated_userid, self.cache_update)
+
+    def can_overwrite_package(self) -> bool:
+        """
+        Return True if the user has permissions to overwrite existing packages
+        """
+        return self.in_any_group(
+            self.request.authenticated_userid, self.allow_overwrite
+        )
+
+    def can_delete_package(self) -> bool:
+        """
+        Return True if the user has permissions to delete packages
+        """
+        return self.in_any_group(self.request.authenticated_userid, self.allow_delete)
 
     def need_admin(self) -> bool:
         """

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -162,7 +162,7 @@ class ICache(object):
         package : :class:`~pypicloud.models.Package`
 
         """
-        if not self.allow_delete:
+        if not self.allow_delete and not self.request.access.is_admin(self.request.authenticated_userid):
             raise ValueError(
                 "Cannot delete packages. Set pypi.allow_delete = true if you want to enable deletes."
             )

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -162,7 +162,9 @@ class ICache(object):
         package : :class:`~pypicloud.models.Package`
 
         """
-        if not self.allow_delete and not self.request.access.is_admin(self.request.authenticated_userid):
+        if not self.allow_delete and not self.request.access.is_admin(
+            self.request.authenticated_userid
+        ):
             raise ValueError(
                 "Cannot delete packages. Set pypi.allow_delete = true if you want to enable deletes."
             )

--- a/pypicloud/cache/base.py
+++ b/pypicloud/cache/base.py
@@ -131,7 +131,7 @@ class ICache(object):
         filename = posixpath.basename(filename)
         old_pkg = self.fetch(filename)
         metadata["requires_python"] = requires_python
-        if old_pkg is not None and self.request.access.can_overwrite_package() is False:
+        if old_pkg is not None and not self.request.access.can_overwrite_package():
             raise ValueError("Unauthorized to overwrite packages.")
 
         if self.calculate_hashes:
@@ -162,7 +162,7 @@ class ICache(object):
             If user is unauthorized for delete
 
         """
-        if self.request.access.can_delete_package() is False:
+        if not self.request.access.can_delete_package():
             raise ValueError("Unauthorized to delete packages.")
 
         self.storage.delete(package)

--- a/pypicloud/static/partial/package.html
+++ b/pypicloud/static/partial/package.html
@@ -57,7 +57,7 @@
             </td>
             <td>
               {{ package.last_modified * 1000 | date:'yyyy-MM-dd HH:mm' }}
-              <button ng-click="deletePackage(package)" visible="ALLOW_DELETE && can_write && (showDelete || package.deleting)" class="btn btn-danger btn-xs pull-right" ng-disabled="package.deleting">
+              <button ng-click="deletePackage(package)" visible="(ALLOW_DELETE && can_write || IS_ADMIN) && (showDelete || package.deleting)" class="btn btn-danger btn-xs pull-right" ng-disabled="package.deleting">
                 <i class="fa fa-refresh fa-spin" ng-show="package.deleting"></i>
                 Delete
               </button>

--- a/pypicloud/static/partial/package.html
+++ b/pypicloud/static/partial/package.html
@@ -57,7 +57,7 @@
             </td>
             <td>
               {{ package.last_modified * 1000 | date:'yyyy-MM-dd HH:mm' }}
-              <button ng-click="deletePackage(package)" visible="(ALLOW_DELETE && can_write || IS_ADMIN) && (showDelete || package.deleting)" class="btn btn-danger btn-xs pull-right" ng-disabled="package.deleting">
+              <button ng-click="deletePackage(package)" visible="(ALLOW_DELETE && can_write) && (showDelete || package.deleting)" class="btn btn-danger btn-xs pull-right" ng-disabled="package.deleting">
                 <i class="fa fa-refresh fa-spin" ng-show="package.deleting"></i>
                 Delete
               </button>

--- a/pypicloud/templates/base.jinja2
+++ b/pypicloud/templates/base.jinja2
@@ -64,7 +64,7 @@ role="navigation">
     var DEFAULT_READ = {{ request.access.default_read | tojson | safe }};
     var DEFAULT_WRITE = {{ request.access.default_write | tojson | safe }};
     var SECURE_COOKIE = {{ request.registry.secure_cookie | tojson | safe }};
-    var ALLOW_DELETE = {{ request.db.allow_delete | tojson | safe }};
+    var ALLOW_DELETE = {{ request.db.allow_delete.value | tojson | safe }};
   </script>
   {% block scripts %}
   {% endblock %}

--- a/pypicloud/templates/base.jinja2
+++ b/pypicloud/templates/base.jinja2
@@ -64,7 +64,7 @@ role="navigation">
     var DEFAULT_READ = {{ request.access.default_read | tojson | safe }};
     var DEFAULT_WRITE = {{ request.access.default_write | tojson | safe }};
     var SECURE_COOKIE = {{ request.registry.secure_cookie | tojson | safe }};
-    var ALLOW_DELETE = {{ request.db.allow_delete.value | tojson | safe }};
+    var ALLOW_DELETE = {{ request.access.can_delete_package() | tojson | safe }};
   </script>
   {% block scripts %}
   {% endblock %}

--- a/pypicloud/views/api.py
+++ b/pypicloud/views/api.py
@@ -169,7 +169,12 @@ def delete_package(context, request):
     package = request.db.fetch(context.filename)
     if package is None:
         return HTTPBadRequest("Could not find %s" % context.filename)
-    request.db.delete(package)
+
+    try:
+        request.db.delete(package)
+    except ValueError:
+        return HTTPForbidden("Package deletion is unallowed.")
+
     return request.response
 
 

--- a/pypicloud/views/api.py
+++ b/pypicloud/views/api.py
@@ -7,7 +7,12 @@ from tempfile import TemporaryFile
 from paste.httpheaders import CACHE_CONTROL, CONTENT_DISPOSITION
 
 # pylint: enable=E0611
-from pyramid.httpexceptions import HTTPBadRequest, HTTPForbidden, HTTPNotFound
+from pyramid.httpexceptions import (
+    HTTPBadRequest,
+    HTTPConflict,
+    HTTPForbidden,
+    HTTPNotFound,
+)
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
 from pyramid_duh import addslash, argify
@@ -155,7 +160,7 @@ def upload_package(context, request, content, summary=None, requires_python=None
             uploader=request.authenticated_userid,
         )
     except ValueError as e:  # pragma: no cover
-        return HTTPBadRequest(*e.args)
+        return HTTPConflict(*e.args)
 
 
 @view_config(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ REQUIREMENTS = [
     "requests",
     "transaction",
     "zope.sqlalchemy",
-    "aenum",
 ]
 
 EXTRAS = {

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIREMENTS = [
     "requests",
     "transaction",
     "zope.sqlalchemy",
+    "aenum",
 ]
 
 EXTRAS = {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from mock import MagicMock
 from pyramid.testing import DummyRequest
 
+from pypicloud.access import IAccessBackend
 from pypicloud.cache import ICache
 from pypicloud.dateutil import utcnow
 from pypicloud.models import Package
@@ -110,6 +111,41 @@ class DummyCache(ICache):
         self.packages[package.filename] = package
 
 
+class DummyAccess(IAccessBackend):
+
+    """In-memory implementation of IAccessBackend"""
+
+    def __init__(self, request=None, **kwargs):
+        super().__init__(request, **kwargs)
+
+    def groups(self, username=None):
+        return []
+
+    def group_members(self, group):
+        return []
+
+    def is_admin(self, username):
+        return False
+
+    def group_permissions(self, package):
+        return {}
+
+    def user_permissions(self, package):
+        return {}
+
+    def user_package_permissions(self, username):
+        return []
+
+    def group_package_permissions(self, group):
+        return []
+
+    def user_data(self, username=None):
+        return []
+
+    def _get_password_hash(self, username):
+        return ""
+
+
 class MockServerTest(unittest.TestCase):
 
     """Base class for tests that need in-memory ICache objects"""
@@ -117,6 +153,7 @@ class MockServerTest(unittest.TestCase):
     def setUp(self):
         self.request = DummyRequest(registry=MagicMock(), forbid=MagicMock())
         self.db = self.request.db = DummyCache(self.request)
+        self.access = self.request.access = DummyAccess(self.request)
         self.request.path_url = "/path/"
         self.params = {}
         self.request.param = lambda x, y=None: self.params.get(x, y)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -19,7 +19,7 @@ from pypicloud.cache.sql import SQLPackage
 from pypicloud.storage import IStorage
 from pypicloud.util import EnvironSettings
 
-from . import DummyCache, DummyStorage, make_package
+from . import DummyAccess, DummyCache, DummyStorage, make_package
 from .db_utils import get_mysql_url, get_postgres_url, get_sqlite_url
 
 # pylint: disable=W0707
@@ -80,7 +80,9 @@ class TestBaseCache(unittest.TestCase):
 
     def test_no_delete(self):
         """If allow_delete=False, packages cannot be deleted"""
-        cache = DummyCache()
+        request = DummyRequest()
+        request.access = DummyAccess()
+        cache = DummyCache(request)
         cache.allow_delete = False
         pkg = make_package()
         with self.assertRaises(ValueError):
@@ -200,6 +202,7 @@ class TestSQLiteCache(unittest.TestCase):
         super(TestSQLiteCache, self).setUp()
         transaction.begin()
         self.request = DummyRequest()
+        self.access = self.request.access = DummyAccess()
         self.request.tm = transaction.manager
         self.db = SQLCache(self.request, **self.kwargs)
         self.sql = self.db.db

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,7 +14,6 @@ from pyramid.testing import DummyRequest
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
 from pypicloud.cache import ICache, RedisCache, SQLCache
-from pypicloud.cache.base import PackageOverridePermissions
 from pypicloud.cache.dynamo import DynamoCache, DynamoPackage, PackageSummary
 from pypicloud.cache.sql import SQLPackage
 from pypicloud.storage import IStorage
@@ -56,8 +55,10 @@ class TestBaseCache(unittest.TestCase):
 
     def test_upload_overwrite(self):
         """Uploading a preexisting packages overwrites current package"""
-        cache = DummyCache()
-        cache.allow_overwrite = PackageOverridePermissions.WRITE_PERMISSION
+        request = DummyRequest()
+        request.access = DummyAccess(request)
+        cache = DummyCache(request)
+        request.access.allow_overwrite = ["everyone"]
         name, filename, content = "a", "a-1.tar.gz", BytesIO(b"new")
         cache.upload(filename, BytesIO(b"old"), name)
         cache.upload(filename, content, name)
@@ -72,27 +73,31 @@ class TestBaseCache(unittest.TestCase):
 
     def test_upload_no_overwrite(self):
         """If allow_overwrite=False duplicate package throws exception"""
-        cache = DummyCache()
-        cache.allow_overwrite = PackageOverridePermissions.NEVER
+        request = DummyRequest()
+        request.access = DummyAccess(request)
+        cache = DummyCache(request)
+        request.access.allow_overwrite = []
         name, version, filename = "a", "1", "a-1.tar.gz"
         cache.upload(filename, BytesIO(b"test1234"), name, version)
         with self.assertRaises(ValueError):
             cache.upload(filename, BytesIO(b"test1234"), name, version)
 
     def test_no_delete(self):
-        """If allow_delete=False, packages cannot be deleted"""
+        """If allow_delete=[], packages cannot be deleted"""
         request = DummyRequest()
-        request.access = DummyAccess()
+        request.access = DummyAccess(request)
         cache = DummyCache(request)
-        cache.allow_delete = PackageOverridePermissions.NEVER
+        request.access.allow_delete = []
         pkg = make_package()
         with self.assertRaises(ValueError):
             cache.delete(pkg)
 
     def test_multiple_packages_same_version(self):
         """Can upload multiple packages that have the same version"""
-        cache = DummyCache()
-        cache.allow_overwrite = PackageOverridePermissions.NEVER
+        request = DummyRequest()
+        request.access = DummyAccess(request)
+        cache = DummyCache(request)
+        request.access.allow_overwrite = []
         name, version = "a", "1"
         path1 = "old_package_path-1.tar.gz"
         cache.upload(path1, BytesIO(b"test1234"), name, version)
@@ -203,7 +208,7 @@ class TestSQLiteCache(unittest.TestCase):
         super(TestSQLiteCache, self).setUp()
         transaction.begin()
         self.request = DummyRequest()
-        self.access = self.request.access = DummyAccess()
+        self.access = self.request.access = DummyAccess(self.request)
         self.request.tm = transaction.manager
         self.db = SQLCache(self.request, **self.kwargs)
         self.sql = self.db.db
@@ -231,7 +236,7 @@ class TestSQLiteCache(unittest.TestCase):
 
     def test_upload_overwrite(self):
         """Uploading a preexisting packages overwrites current package"""
-        self.db.allow_overwrite = True
+        self.request.access.allow_overwrite = ["everyone"]
         name, filename = "a", "a-1.tar.gz"
         self.db.upload(filename, BytesIO(b"old"), name)
         self.db.upload(filename, BytesIO(b"new"), name)
@@ -259,6 +264,7 @@ class TestSQLiteCache(unittest.TestCase):
 
     def test_delete(self):
         """delete() removes object from database and deletes from storage"""
+        self.request.access.allow_delete = ["everyone"]
         pkg = make_package(factory=SQLPackage)
         self.sql.add(pkg)
         transaction.commit()
@@ -273,6 +279,7 @@ class TestSQLiteCache(unittest.TestCase):
         pkg = make_package(factory=SQLPackage)
         self.sql.add(pkg)
         transaction.commit()
+        self.request.access.can_delete_package = lambda: True
         self.sql.add(pkg)
         self.db.delete(pkg)
         count = self.sql.query(SQLPackage).count()
@@ -393,7 +400,7 @@ class TestSQLiteCache(unittest.TestCase):
 
     def test_multiple_packages_same_version(self):
         """Can upload multiple packages that have the same version"""
-        with patch.object(self.db, "allow_overwrite", False):
+        with patch.object(self.request.access, "allow_overwrite", []):
             name, version = "a", "1"
             path1 = "old_package_path-1.tar.gz"
             self.db.upload(path1, BytesIO(b"test1234"), name, version)
@@ -480,7 +487,9 @@ class TestRedisCache(unittest.TestCase):
 
     def setUp(self):
         super(TestRedisCache, self).setUp()
-        self.db = RedisCache(DummyRequest(), **self.kwargs)
+        self.request = DummyRequest()
+        self.access = self.request.access = DummyAccess(self.request)
+        self.db = RedisCache(self.request, **self.kwargs)
         self.storage = self.db.storage = MagicMock(spec=IStorage)
 
     def tearDown(self):
@@ -525,6 +534,7 @@ class TestRedisCache(unittest.TestCase):
 
     def test_delete(self):
         """delete() removes object from database and deletes from storage"""
+        self.request.access.allow_delete = ["everyone"]
         pkg = make_package()
         key = self.db.redis_key(pkg.filename)
         self.redis[key] = "foobar"
@@ -676,7 +686,7 @@ class TestRedisCache(unittest.TestCase):
 
     def test_multiple_packages_same_version(self):
         """Can upload multiple packages that have the same version"""
-        with patch.object(self.db, "allow_overwrite", False):
+        with patch.object(self.request.access, "allow_overwrite", []):
             name, version = "a", "1"
             path1 = "old_package_path-1.tar.gz"
             self.db.upload(path1, BytesIO(b"test1234"), name, version)
@@ -789,7 +799,9 @@ class TestDynamoCache(unittest.TestCase):
 
     def setUp(self):
         super(TestDynamoCache, self).setUp()
-        self.db = DynamoCache(DummyRequest(), **self.kwargs)
+        self.request = DummyRequest()
+        self.access = self.request.access = DummyAccess(self.request)
+        self.db = DynamoCache(self.request, **self.kwargs)
         self.storage = self.db.storage = MagicMock(spec=IStorage)
 
     def tearDown(self):
@@ -825,6 +837,7 @@ class TestDynamoCache(unittest.TestCase):
 
     def test_delete(self):
         """delete() removes object from database and deletes from storage"""
+        self.request.access.allow_delete = ["everyone"]
         pkg = make_package(factory=DynamoPackage)
         self._save_pkgs(pkg)
         self.db.delete(pkg)
@@ -836,6 +849,7 @@ class TestDynamoCache(unittest.TestCase):
 
     def test_clear(self):
         """clear() removes object from database"""
+        self.request.access.allow_delete = ["everyone"]
         pkg = make_package(factory=DynamoPackage)
         self._save_pkgs(pkg)
         self.db.delete(pkg)
@@ -956,7 +970,7 @@ class TestDynamoCache(unittest.TestCase):
 
     def test_multiple_packages_same_version(self):
         """Can upload multiple packages that have the same version"""
-        with patch.object(self.db, "allow_overwrite", False):
+        with patch.object(self.request.access, "allow_overwrite", []):
             name, version = "a", "1"
             path1 = "old_package_path-1.tar.gz"
             self.db.upload(path1, BytesIO(b"test1234"), name, version)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -143,8 +143,8 @@ class TestEndpointSecurityAdmin(unittest.TestCase):
             "pyramid.debug_authorization": True,
             "pypi.db": "tests.test_security.GlobalDummyCache",
             "pypi.storage": "tests.test_security.GlobalDummyStorage",
-            "pypi.allow_overwrite": ["admin"],
-            "pypi.allow_delete": ["admin"],
+            "pypi.allow_overwrite_groups": ["admin"],
+            "pypi.allow_delete_groups": ["admin"],
             "session.validate_key": "a",
             "user.user": sha256_crypt.encrypt("user"),
             "user.admin": sha256_crypt.encrypt("admin"),
@@ -190,7 +190,7 @@ class TestEndpointSecurityAdmin(unittest.TestCase):
         self.assertEqual(response.status_int, 200)
 
     def test_api_pkg_delete_weak_user(self):
-        """/api/package/<pkg>/<filename> validates allow_delete setting"""
+        """/api/package/<pkg>/<filename> validates allow_delete_groups setting"""
 
         response = self.app.delete(
             "/api/package/{package_name}/{filename}".format(
@@ -202,7 +202,7 @@ class TestEndpointSecurityAdmin(unittest.TestCase):
         self.assertEqual(response.status_int, 403)
 
     def test_api_pkg_delete_admin(self):
-        """/api/package/<pkg>/<filename> validates allow_delete setting"""
+        """/api/package/<pkg>/<filename> validates allow_delete_groups setting"""
         response = self.app.delete(
             "/api/package/{package_name}/{filename}".format(
                 package_name=self.package.name, filename=self.package.filename

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -134,9 +134,77 @@ class TestEndpointSecurity(unittest.TestCase):
         response = self.app.delete(url, headers=_auth("user2", "user2"))
         self.assertEqual(response.status_int, 200)
 
-    def test_api_rebuild_admin(self):
-        """/api/rebuild requires admin"""
+
+class TestEndpointSecurityAdmin(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.package = package = make_package()
+        settings = {
+            "pyramid.debug_authorization": True,
+            "pypi.db": "tests.test_security.GlobalDummyCache",
+            "pypi.storage": "tests.test_security.GlobalDummyStorage",
+            "pypi.allow_delete": False,
+            "session.validate_key": "a",
+            "user.user": sha256_crypt.encrypt("user"),
+            "user.admin": sha256_crypt.encrypt("admin"),
+            "package.%s.user.user" % package.name: "rw",
+            "auth.admins": ["admin"],
+        }
+        app = main({}, **settings)
+        cls.app = webtest.TestApp(app)
+
+    def setUp(self):
+        cache = GlobalDummyCache()
+        cache.upload(
+            self.package.filename,
+            BytesIO(b"test1234"),
+            self.package.name,
+            self.package.version,
+        )
+
+    def tearDown(self):
+        GlobalDummyCache.global_packages.clear()
+        GlobalDummyStorage.global_packages.clear()
+        self.app.reset()
+
+    def test_api_pkg_delete_weak_user(self):
+        """/api/package/<pkg>/<filename> validates allow_delete setting"""
+
+        response = self.app.delete(
+            "/api/package/{package_name}/{filename}".format(
+                package_name=self.package.name, filename=self.package.filename
+            ),
+            expect_errors=True,
+            headers=_auth("user", "user"),
+        )
+        self.assertEqual(response.status_int, 403)
+
+    def test_api_pkg_delete_admin(self):
+        """/api/package/<pkg>/<filename> validates allow_delete setting"""
+        response = self.app.delete(
+            "/api/package/{package_name}/{filename}".format(
+                package_name=self.package.name, filename=self.package.filename
+            ),
+            headers=_auth("admin", "admin"),
+        )
+        self.assertEqual(response.status_int, 200)
+
+    def test_rebuild_weak_user(self):
+        """/admin/rebuild requires admin"""
         response = self.app.get(
-            "/api/rebuild/", expect_errors=True, headers=_auth("user2", "user2")
+            "/admin/rebuild/", expect_errors=True, headers=_auth("user", "user")
+        )
+        self.assertEqual(response.status_int, 403)
+
+    def test_rebuild_admin(self):
+        """/admin/rebuild requires admin"""
+        response = self.app.get("/admin/rebuild/", headers=_auth("admin", "admin"))
+        self.assertEqual(response.status_int, 200)
+
+    def test_api_unknown_url(self):
+        """unknown url returns 404"""
+        response = self.app.get(
+            "/api/non_existant_url/",
+            expect_errors=True,
         )
         self.assertEqual(response.status_int, 404)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -8,7 +8,6 @@ import webtest
 from passlib.hash import sha256_crypt  # pylint: disable=E0611
 
 from pypicloud import main
-from pypicloud.cache.base import PackageOverridePermissions
 
 from . import DummyCache, DummyStorage, make_package
 
@@ -144,8 +143,8 @@ class TestEndpointSecurityAdmin(unittest.TestCase):
             "pyramid.debug_authorization": True,
             "pypi.db": "tests.test_security.GlobalDummyCache",
             "pypi.storage": "tests.test_security.GlobalDummyStorage",
-            "pypi.allow_overwrite": PackageOverridePermissions.ADMIN_PERMISSION.value,
-            "pypi.allow_delete": PackageOverridePermissions.ADMIN_PERMISSION.value,
+            "pypi.allow_overwrite": ["admin"],
+            "pypi.allow_delete": ["admin"],
             "session.validate_key": "a",
             "user.user": sha256_crypt.encrypt("user"),
             "user.admin": sha256_crypt.encrypt("admin"),

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -59,6 +59,7 @@ class TestSimple(MockServerTest):
 
     def test_upload_duplicate(self):
         """Uploading a duplicate package returns 409"""
+        self.request.access.can_overwrite_package.return_value = False
         self.params = {":action": "file_upload"}
         name, version, content = "foo", "1.2", FileUpload("testfile", b"test1234")
         content.filename = "foo-1.2.tar.gz"
@@ -70,7 +71,7 @@ class TestSimple(MockServerTest):
         """Pip search executes successfully"""
         self.params = {":action": "file_upload"}
         name1, version1, content1 = "foo", "1.1", FileUpload("testfile", b"test1234")
-        content1.filename = "bar-1.2.tar.gz"
+        content1.filename = "foo-1.2.tar.gz"
         name2, version2, content2 = "bar", "1.0", FileUpload("testfile", b"test1234")
         content2.filename = "bar-1.2.tar.gz"
         upload(self.request, content1, name1, version1)


### PR DESCRIPTION
Now if `pypi.allow_delete` is false there is no way to delete any package, even as an admin on pypicloud.
This PR opens the possibility for admins (only) to still delete packages even if allow_delete is False.