### PR TITLE
Fixed sort in when using redis cache

### DIFF
--- a/pypicloud/cache/redis_cache.py
+++ b/pypicloud/cache/redis_cache.py
@@ -97,7 +97,7 @@ class RedisCache(ICache):
         return packages
 
     def distinct(self):
-        return list(self.db.smembers(self.redis_set))
+        return sorted(self.db.smembers(self.redis_set))
 
     def summary(self):
         return self._load_summaries(self.db.smembers(self.redis_set))


### PR DESCRIPTION
Now sorting packages alphabetically when using redis cache (it works this way on all other caches).
