### PR TITLE
Fix pypicloud breaking when storage.region_name = "us-east-1"

### DIFF
--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -113,7 +113,7 @@ class S3Storage(ObjectStoreStorage):
             if e.response["Error"]["Code"] == "404":
                 LOG.info("Creating S3 bucket %s", bucket_name)
 
-                if config.region_name:
+                if config.region_name and config.region_name != "us-east-1":
                     location = {"LocationConstraint": config.region_name}
                     bucket.create(CreateBucketConfiguration=location)
                 else:


### PR DESCRIPTION
us-east-1 is an invalid value for location constraint. [ref](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) and [ref](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html)
The current logic means that if storage.region_name is set to "us-east-1" then the deployment will crash.

It could be argued that someone could not set this value in the config if their region were us-east-1 and it wouldn't be unfair.
However, this very minor update means that things "just work" if you always set the region_name, which IMHO is a worthwhile QOL update.