### PR TITLE
Investigation: Add support for instance profiles

### DIFF
--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -167,7 +167,7 @@ class S3Storage(ObjectStoreStorage):
         boto3 will handle updating the credentials automatically, but the resource itself can't be kept alive forever, else subsequent calls
         result in expired credentials errors.
 
-        Separating create_bucket_if_not_exists here from get_bucket to avoid unnecessary increase in bucket.head calls
+        Separating create_bucket_if_not_exists here from returning a new bucket resource to avoid unnecessary increase in bucket.head calls
         that would be introduced by implementing self.bucket as a property.
         """
         if self._bucket is None:

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -113,7 +113,7 @@ class S3Storage(ObjectStoreStorage):
             if e.response["Error"]["Code"] == "404":
                 LOG.info("Creating S3 bucket %s", bucket_name)
 
-                if config.region_name:
+                if config.region_name and config.region_name != "us-east-1":
                     location = {"LocationConstraint": config.region_name}
                     bucket.create(CreateBucketConfiguration=location)
                 else:

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -40,7 +40,12 @@ class S3Storage(ObjectStoreStorage):
     test = False
 
     def __init__(
-        self, request=None, bucket_name=None, storage_config=None, resource_config=None, **kwargs
+        self,
+        request=None,
+        bucket_name=None,
+        storage_config=None,
+        resource_config=None,
+        **kwargs,
     ):
         super(S3Storage, self).__init__(request=request, **kwargs)
         self.bucket_name = bucket_name if bucket_name is not None else ""
@@ -114,7 +119,9 @@ class S3Storage(ObjectStoreStorage):
 
     def create_bucket_if_not_exist(self):
 
-        s3Resource = boto3.resource("s3", config=self.storage_config, **self.resource_config)
+        s3Resource = boto3.resource(
+            "s3", config=self.storage_config, **self.resource_config
+        )
 
         bucket = s3Resource.Bucket(self.bucket_name)
         try:
@@ -156,7 +163,9 @@ class S3Storage(ObjectStoreStorage):
                 LOG.warning("S3 file %s has no package name", obj.key)
                 return None
 
-        return factory(name, version, filename, obj.last_modified, path=obj.key, **metadata)
+        return factory(
+            name, version, filename, obj.last_modified, path=obj.key, **metadata
+        )
 
     @property
     def bucket(self):
@@ -173,7 +182,9 @@ class S3Storage(ObjectStoreStorage):
         if self._bucket is None:
             self._bucket = self.create_bucket_if_not_exist()
         else:
-            s3Resource = boto3.resource("s3", config=self.storage_config, **self.resource_config)
+            s3Resource = boto3.resource(
+                "s3", config=self.storage_config, **self.resource_config
+            )
             self._bucket = s3Resource.Bucket(self.bucket_name)
         return self._bucket
 
@@ -267,7 +278,9 @@ class S3Storage(ObjectStoreStorage):
         )
 
     def delete(self, package):
-        self.bucket.delete_objects(Delete={"Objects": [{"Key": self.get_path(package)}]})
+        self.bucket.delete_objects(
+            Delete={"Objects": [{"Key": self.get_path(package)}]}
+        )
 
     def check_health(self):
         """Check the health.
@@ -290,7 +303,9 @@ class CloudFrontS3Storage(S3Storage):
 
     """Storage backend that uses S3 and CloudFront"""
 
-    def __init__(self, request=None, domain=None, crypto_pk=None, key_id=None, **kwargs):
+    def __init__(
+        self, request=None, domain=None, crypto_pk=None, key_id=None, **kwargs
+    ):
         super(CloudFrontS3Storage, self).__init__(request, **kwargs)
         self.domain = domain
         self.crypto_pk = crypto_pk

--- a/pypicloud/storage/s3.py
+++ b/pypicloud/storage/s3.py
@@ -283,20 +283,12 @@ class S3Storage(ObjectStoreStorage):
         )
 
     def check_health(self):
-        """Check the health.
-
-        suggestion:
-            When deployed in environments that repeatedly hit the pypicloud server for health checks,
-            the below might not be very useful?
-            The bucket will exist and we will have access to it due to calling head_bucket much earlier during initialization.
-            Doing so repeatedly (every 5-10 seconds, etc) increases AWS api costs and seemingly provides little actual value.
-
-            In line with this suggestion, updating this to just always return True, "" for now.
-            I suppose an argument could be made that this validates our connectivity to AWS, but if that is failing we won't need this health check to tell us that...
-        Returns:
-        """
-
-        return True, ""
+        try:
+            self.bucket.meta.client.head_bucket(Bucket=self.bucket_name)
+        except ClientError as e:
+            return False, str(e)
+        else:
+            return True, ""
 
 
 class CloudFrontS3Storage(S3Storage):


### PR DESCRIPTION
dependent on / includes changes from #321 

Related to issue #319 

This is an initial pass at the implementation, and is functionally tested (by me) and is running in a deployed environment.
I've been trying to track down *exactly* how/where/when/why but here's what I believe I've observed:

Caveat: while I have a number of years of experience as a developer/programmer/engineer, i've traditionally stayed away from specifically web programming, so might be missing some of the web server specific details.

The current implementation of pypicloud (the one on master) appears to creates the storage backend once, when the cache is created [ref](https://github.com/stevearc/pypicloud/blob/master/pypicloud/cache/base.py#L28)
In the case of the S3 backend this in turn creates a reference to the bucket resource (boto3.resource("s3").Bucket). 

It appears that this bucket is kept alive for an indeterminate amount of time. To be honest, it seems like it's kept alive for the length of the server from what i'm observing, but the "request" argument to the constructor is really making me doubt myself here.

I do know that *without* these patches (or equivalent) we reproducibly observe 500 - internal server error messages (which when you look at the logs on the pod are specifically expired credentials) about 15 minutes after server startup, which is the same length of time that the instance profile credentials are valid for.

Generally, Boto3 / botocore will handle rotating the instance profile credentials automatically in almost all cases, transparently to the user. It appears however that the resource objects do *not* automatically refresh their credentials when they are long lived. This observation is what led me to suspect that the resource is kept alive.

The implementation here makes the `self.bucket` member a property which will create the bucket if it doesn't exist the first time it's retrieved and will return a new boto3 Bucket resource to that same bucket on subsequent calls.

This should hopefully minimize any disruption to anyone else.

I ended up removing the `get_bucket` method since it was only used in one location, but am happy to add it back; it ended up being only the two lines that are now the in bucket getter, so it seemed redundant to keep it as a separate function. 

I also added a few (What I believed to be minor) updates, and left comments explaining my thinking where I thought it'd be useful. 

Welcome all feedback and discussion here; this is now the last remaining patch I manually maintain for our deployments so i'd be very happy to see it merged upstream.

TYVM!
-Tyler


