### PR TITLE
fix: add slash to stop pointless redirect

### DIFF
--- a/pypicloud/static/js/pypicloud.js
+++ b/pypicloud/static/js/pypicloud.js
@@ -370,7 +370,7 @@ angular
       };
 
       $http
-        .get($scope.API + "package/" + $scope.package_name)
+        .get($scope.API + "package/" + $scope.package_name + "/")
         .success(function (data, status, headers, config) {
           $scope.packages = data.packages;
           $scope.filtered = data.packages;

--- a/pypicloud/templates/simple.jinja2
+++ b/pypicloud/templates/simple.jinja2
@@ -5,7 +5,7 @@
 </head>
 <body>
   {% for pkg in pkgs %}
-    <a href="{{ pkg }}">{{ pkg }}</a><br>
+    <a href="{{ pkg }}/">{{ pkg }}</a><br>
   {%- endfor %}
 </body>
 </html>


### PR DESCRIPTION
because you have `addslash` [here](https://github.com/stevearc/pypicloud/blob/master/pypicloud/views/simple.py#L109) all these urls are redirects