### PR TITLE
Do not search for releases when fallback disallowed

### DIFF
--- a/pypicloud/views/simple.py
+++ b/pypicloud/views/simple.py
@@ -161,10 +161,10 @@ def package_versions_json(context, request):
 
 def get_fallback_packages(request, package_name, redirect=True):
     """Get all package versions for a package from the fallback_base_url"""
-    releases = request.locator.get_releases(package_name)
     pkgs = {}
     if not request.access.has_permission(package_name, "fallback"):
         return pkgs
+    releases = request.locator.get_releases(package_name)
     for release in releases:
         url = release["url"]
         filename = posixpath.basename(url)


### PR DESCRIPTION
The fuction "request.locator.get_releases" looking for releases in an upstream was called regardless of permissions that were set on a given package. Looking for releases of packages in the upstream that were disallowed by the "pypi.disallow_fallback" option exposed the names of disallowed packages to the upstream. This is unsolicited behavior.

This change also fixes these warnings that were logged for all disallowed packages:

WARNING [pypicloud.locator] Error fetching 'package1' from upstream: 404 Client Error: Not Found for url: https://pypi.org/pypi/package1/json

Fixed issue #327