### PR TITLE
Set pypi.default_read = authenticated in ppc-make-config

### DIFF
--- a/pypicloud/templates/config.ini.jinja2
+++ b/pypicloud/templates/config.ini.jinja2
@@ -8,7 +8,7 @@ pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 
 pypi.default_read =
-    {% if env == 'prod' -%}
+    {% if env == 'prod' or env == 'docker' -%}
       authenticated
     {%- else -%}
       everyone


### PR DESCRIPTION
Hi 👋 

We found out that our kubernetes cluster was exposing packages due to `default_read=everyone`. We created the config for our cluster using the 'docker mode' (`ppc-make-config -r`). This default was unexpected to us, also because of the [docs](https://pypicloud.readthedocs.io/en/latest/topics/configuration.html#pypi-default-read) stating `authendicated` as default value.