### PR TITLE
remove convert_unicode flag

### DIFF
--- a/pypicloud/cache/sql.py
+++ b/pypicloud/cache/sql.py
@@ -103,9 +103,9 @@ class SQLPackage(Package, Base):
     """Python package stored in SQLAlchemy"""
 
     __tablename__ = "packages"
-    filename = Column(String(255, convert_unicode=True), primary_key=True)
-    name = Column(String(255, convert_unicode=True), index=True, nullable=False)
-    version = Column(String(1000, convert_unicode=True), nullable=False)
+    filename = Column(String(255), primary_key=True)
+    name = Column(String(255), index=True, nullable=False)
+    version = Column(String(1000), nullable=False)
     last_modified = Column(TZAwareDateTime(), index=True, nullable=False)
     # TEXT, as pypi does the same, and using String(N) would mismatch with pypi
     summary = Column(Text(), nullable=True)


### PR DESCRIPTION
In SQLAlchemy 1.4 and later versions, . SQLAlchemy handles Unicode and string encoding automatically based on the database backend and configuration

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/paste/deploy/loadwsgi.py", line 248, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/local/lib/python3.9/site-packages/paste/deploy/loadwsgi.py", line 273, in loadobj
    return context.create()
  File "/usr/local/lib/python3.9/site-packages/paste/deploy/loadwsgi.py", line 741, in create
    return self.object_type.invoke(self)
  File "/usr/local/lib/python3.9/site-packages/paste/deploy/loadwsgi.py", line 138, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/usr/local/lib/python3.9/site-packages/paste/deploy/util.py", line 64, in fix_call
    raise exc_info[1] from None
  File "/usr/local/lib/python3.9/site-packages/paste/deploy/util.py", line 61, in fix_call
    val = callable(*args, **kw)
  File "/usr/local/lib/python3.9/site-packages/pypicloud/__init__.py", line 207, in main
    config.include("pypicloud")
  File "/usr/local/lib/python3.9/site-packages/pyramid/config/__init__.py", line 666, in include
    c(configurator)
  File "/usr/local/lib/python3.9/site-packages/pypicloud/__init__.py", line 89, in includeme
    config.include("pypicloud.cache")
  File "/usr/local/lib/python3.9/site-packages/pyramid/config/__init__.py", line 632, in include
    c = self.maybe_dotted(callable)
  File "/usr/local/lib/python3.9/site-packages/pyramid/config/__init__.py", line 740, in maybe_dotted
    return self.name_resolver.maybe_resolve(dotted)
  File "/usr/local/lib/python3.9/site-packages/pyramid/path.py", line 327, in maybe_resolve
    return self._resolve(dotted, package)
  File "/usr/local/lib/python3.9/site-packages/pyramid/path.py", line 334, in _resolve
    return self._zope_dottedname_style(dotted, package)
  File "/usr/local/lib/python3.9/site-packages/pyramid/path.py", line 389, in _zope_dottedname_style
    __import__(used)
  File "/usr/local/lib/python3.9/site-packages/pypicloud/cache/__init__.py", line 8, in <module>
    from .sql import SQLCache
  File "/usr/local/lib/python3.9/site-packages/pypicloud/cache/sql.py", line 101, in <module>
    class SQLPackage(Package, Base):
  File "/usr/local/lib/python3.9/site-packages/pypicloud/cache/sql.py", line 106, in SQLPackage
    filename = Column(String(255, convert_unicode=True), primary_key=True)
TypeError: __init__() got an unexpected keyword argument 'convert_unicode'
```